### PR TITLE
chore: Add CODEOWNERS rule for yarn.lock and package.json to the Security team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Security
+
+**/yarn.lock @phantom/security
+**/package.json @phantom/security


### PR DESCRIPTION
## Description

Assign the yarn.lock and package.json files to the security code owners.
This will ensure that any updates made to this file in a pull request will require a mandatory review by the security team.