### PR TITLE
Fix wallet container height to ensure Close button visibility at Receive 

### DIFF
--- a/packages/demo-app/src/components/WalletContainer.tsx
+++ b/packages/demo-app/src/components/WalletContainer.tsx
@@ -6,7 +6,7 @@ export const WalletContainer: React.FC = React.memo(() => {
       id="wallet-container"
       style={{
         width: "400px",
-        height: "747px",
+        height: "747px", // Updated height
         margin: "20px auto",
         border: "1px dashed #ccc",
         position: "relative",

--- a/packages/demo-app/src/components/WalletContainer.tsx
+++ b/packages/demo-app/src/components/WalletContainer.tsx
@@ -6,7 +6,7 @@ export const WalletContainer: React.FC = React.memo(() => {
       id="wallet-container"
       style={{
         width: "400px",
-        height: "600px",
+        height: "747px",
         margin: "20px auto",
         border: "1px dashed #ccc",
         position: "relative",


### PR DESCRIPTION
Previously, the Close button was not visible at all after clicking on the 'Receive' option. This could cause a lot of user experience problems, so I changed the container height to make the close button visible in the 'Receive' option of the element configuration.