### PR TITLE
feat: Skip injection

### DIFF
--- a/.changeset/calm-vans-lay.md
+++ b/.changeset/calm-vans-lay.md
@@ -1,0 +1,5 @@
+---
+"@phantom/wallet-sdk": minor
+---
+
+Added skip injection parameter

--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ phantom.swap({
 }); // Swap SOL to USDC
 ```
 
+### Skip Injection Mode
+
+If you want to avoid injecting providers into the global window object, you can use the `skipInjection` option:
+
+```typescript
+// Create a wallet instance with skipInjection enabled
+const phantom = await createPhantom({
+  skipInjection: true,
+});
+
+// All providers are available through the phantom instance only
+const solanaPublicKey = await phantom.solana.connect();
+```
+
+This is useful when you want to avoid any global namespace pollution and prefer to access all functionality through the returned Phantom instance.
+
 ## Blockchain RPC Interfaces
 
 The SDK provides access to Phantom's blockchain-specific RPC interfaces:
@@ -108,9 +124,11 @@ interested in working with us, please email us at `developers@phantom.app` or me
 
     Once `createPhantom` has been called, `window.phantom.solana` and a compliant wallet-standard provider will also be available in the global scope of your website. This means that most of your existing code for interacting with Solana wallets should work out of the box.
 
-    Once a user has onboarded to the embedded wallet, they should be able to click your “connect wallet” button, which gives your website access to their Solana address. After that, signing messages and transactions should just work as normal.
+    Once a user has onboarded to the embedded wallet, they should be able to click your "connect wallet" button, which gives your website access to their Solana address. After that, signing messages and transactions should just work as normal.
 
     If you use a namespace, you will need to invoke the functions through the `window[namespace]` object, or directly through the returned Phantom instance.
+
+    If you use `skipInjection: true`, all providers will only be available through the returned Phantom instance.
 
 </details>
 <details>

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -102,13 +102,21 @@ In this case, you must use the returned object for all interactions:
 const publicKey = await phantom.solana.connect();
 ```
 
-### Usage with Existing dApps
+### Skip Injection Behavior
 
-For existing dApps that detect and use standard provider patterns:
+When you set `skipInjection` to `true`:
 
-1. **Extension Installed**: The dApp will use the extension as normal
-2. **No Extension, Default Namespace**: The dApp will use the embedded wallet through the standard window objects
-3. **Custom Namespace**: You'll need to modify your dApp code to use the custom instance
+```typescript
+const phantom = await createPhantom({ skipInjection: true });
+```
+
+The SDK will:
+
+1. Not inject any providers into the window object, even if no extension is detected
+2. Return all providers through the Phantom instance only
+3. Work with the new event structure that passes providers directly in the event detail
+
+This is useful when you want to avoid any global namespace pollution and prefer to access all functionality through the returned Phantom instance.
 
 ## Configuration Options
 
@@ -127,6 +135,7 @@ export type CreatePhantomConfig = Partial<{
   sdkURL: string; // Custom SDK URL
   element: string; // ID of element to render wallet in (for custom positioning)
   namespace: string; // Namespace for the wallet instance
+  skipInjection: boolean; // Skip injecting providers into the window object
 }>;
 ```
 


### PR DESCRIPTION
This pull request introduces a new feature to the Phantom wallet SDK, allowing users to skip the injection of providers into the global window object. This feature aims to reduce global namespace pollution and ensure that all functionality is accessed through the returned Phantom instance. The most important changes include updates to the SDK configuration, documentation, and the implementation of the `createPhantom` function.

### New Feature: Skip Injection

* **SDK Configuration Update**:
  - Added `skipInjection` parameter to `CreatePhantomConfig` type in `packages/sdk/src/index.ts` and `packages/sdk/README.md`. [[1]](diffhunk://#diff-7defdb66d87b1af98d5f3645f0da5fec53479a6f59a38af6fd2c9b619dd5f58cR22) [[2]](diffhunk://#diff-fb389a13c110d5b92cb85e2a1eb937b649ff8adc09a19626ab6cbc9218bb6d83R138)

* **Implementation Changes**:
  - Updated `createPhantom` function to handle the `skipInjection` parameter and return providers through the Phantom instance only if `skipInjection` is set to `true`. [[1]](diffhunk://#diff-7defdb66d87b1af98d5f3645f0da5fec53479a6f59a38af6fd2c9b619dd5f58cR88-R93) [[2]](diffhunk://#diff-7defdb66d87b1af98d5f3645f0da5fec53479a6f59a38af6fd2c9b619dd5f58cL105-R126) [[3]](diffhunk://#diff-7defdb66d87b1af98d5f3645f0da5fec53479a6f59a38af6fd2c9b619dd5f58cL121-R153)

* **Documentation Updates**:
  - Added a new section on "Skip Injection Mode" in `README.md` to explain the usage and benefits of the `skipInjection` option. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R63-R78) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L111-R132)
  - Updated the `README.md` in `packages/sdk` to include details about the "Skip Injection Behavior".

* **Changeset**:
  - Added a changeset file to document the addition of the `skipInjection` parameter as a minor update. (`.changeset/calm-vans-lay.md`)