### PR TITLE
chore: refactor to plugins from chainPlugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ import { createPhantom } from "@phantom/browser-sdk";
 import { createSolanaPlugin } from "@phantom/browser-sdk/solana";
 
 const phantom = createPhantom({
-  chainPlugins: [createSolanaPlugin()],
+  plugins: [createSolanaPlugin()],
 });
 
 // Example: connect to wallet
@@ -65,7 +65,7 @@ import { createSolanaPlugin } from "@phantom/browser-sdk/solana";
 
 function App() {
   return (
-    <PhantomProvider config={{ chainPlugins: [createSolanaPlugin()] }}>
+    <PhantomProvider config={{ plugins: [createSolanaPlugin()] }}>
       <WalletComponent />
     </PhantomProvider>
   );

--- a/examples/browser-sdk-demo-app/src/main.ts
+++ b/examples/browser-sdk-demo-app/src/main.ts
@@ -15,7 +15,7 @@ document.addEventListener("DOMContentLoaded", () => {
   console.log("Document loaded, attempting to create Phantom instance...");
   try {
     const phantomInstance = createPhantom({
-      chainPlugins: [createSolanaPlugin()],
+      plugins: [createSolanaPlugin()],
     });
     console.log("Phantom instance created:", phantomInstance);
 

--- a/examples/react-sdk-demo-app/src/App.tsx
+++ b/examples/react-sdk-demo-app/src/App.tsx
@@ -3,7 +3,7 @@ import { createSolanaPlugin } from "@phantom/browser-sdk/solana";
 import { Actions } from "./Actions";
 
 const phantomConfig = {
-  chainPlugins: [createSolanaPlugin()],
+  plugins: [createSolanaPlugin()],
 };
 
 function App() {

--- a/packages/browser-sdk/README.md
+++ b/packages/browser-sdk/README.md
@@ -28,7 +28,7 @@ import { createSolanaPlugin } from "@phantom/browser-sdk/solana"; // Import the 
 
 // Create a Phantom instance with the Solana plugin
 const phantom = createPhantom({
-  chainPlugins: [createSolanaPlugin()],
+  plugins: [createSolanaPlugin()],
 });
 
 // Now you can use the Solana-specific methods
@@ -89,7 +89,7 @@ The SDK also allows you to listen for `connect`, `disconnect`, and `accountChang
   **Example:**
 
   ```typescript
-  const phantom = createPhantom({ chainPlugins: [createSolanaPlugin()] });
+  const phantom = createPhantom({ plugins: [createSolanaPlugin()] });
 
   const handleConnect = (address: string) => {
     console.log(`Wallet connected with public key: ${address}`);
@@ -115,7 +115,7 @@ The SDK also allows you to listen for `connect`, `disconnect`, and `accountChang
   **Example:**
 
   ```typescript
-  const phantom = createPhantom({ chainPlugins: [createSolanaPlugin()] });
+  const phantom = createPhantom({ plugins: [createSolanaPlugin()] });
 
   const handleDisconnect = () => {
     console.log("Wallet disconnected");

--- a/packages/browser-sdk/src/index.ts
+++ b/packages/browser-sdk/src/index.ts
@@ -1,23 +1,23 @@
-export type ChainPlugin<T> = {
+export type Plugin<T> = {
   name: string;
   create: () => T;
 };
 
 export type CreatePhantomConfig = {
-  chainPlugins?: ChainPlugin<unknown>[];
+  plugins?: Plugin<unknown>[];
 };
 
 // Base interface that plugins will extend via declaration merging
 export interface Phantom {}
 
 /**
- * Creates a Phantom instance with the provided chain plugins.
+ * Creates a Phantom instance with the provided plugins.
  * Each plugin extends the Phantom interface via declaration merging.
  */
-export function createPhantom({ chainPlugins = [] }: CreatePhantomConfig): Phantom {
+export function createPhantom({ plugins = [] }: CreatePhantomConfig): Phantom {
   const phantom: Record<string, unknown> = {};
 
-  for (const plugin of chainPlugins) {
+  for (const plugin of plugins) {
     phantom[plugin.name] = plugin.create();
   }
 

--- a/packages/browser-sdk/src/solana/plugin.ts
+++ b/packages/browser-sdk/src/solana/plugin.ts
@@ -1,4 +1,4 @@
-import type { ChainPlugin } from "../index";
+import type { Plugin } from "../index";
 import { connect } from "./connect";
 import { disconnect } from "./disconnect";
 import { addEventListener, removeEventListener, type PhantomEventCallback } from "./eventListeners";
@@ -30,7 +30,7 @@ const solana: Solana = {
   removeEventListener,
 };
 
-export function createSolanaPlugin(): ChainPlugin<Solana> {
+export function createSolanaPlugin(): Plugin<Solana> {
   return {
     name: "solana",
     create: () => solana,

--- a/packages/react-sdk/README.md
+++ b/packages/react-sdk/README.md
@@ -17,7 +17,7 @@ import { createSolanaPlugin } from "@phantom/browser-sdk/solana";
 
 function App() {
   return (
-    <PhantomProvider config={{ chainPlugins: [createSolanaPlugin()] }}>
+    <PhantomProvider config={{ plugins: [createSolanaPlugin()] }}>
       <WalletComponent />
     </PhantomProvider>
   );
@@ -55,7 +55,7 @@ The PhantomProvider component provides the Phantom context to child components.
 import { PhantomProvider } from "@phantom/react-sdk";
 import { createSolanaPlugin } from "@phantom/browser-sdk/solana";
 
-<PhantomProvider config={{ chainPlugins: [createSolanaPlugin()] }}>{children}</PhantomProvider>;
+<PhantomProvider config={{ plugins: [createSolanaPlugin()] }}>{children}</PhantomProvider>;
 ```
 
 ### usePhantom

--- a/packages/react-sdk/src/solana/useAccount.test.tsx
+++ b/packages/react-sdk/src/solana/useAccount.test.tsx
@@ -24,7 +24,7 @@ const sharedConfig = {
   wrapper: ({ children }: { children: React.ReactNode }) => (
     <PhantomProvider
       config={{
-        chainPlugins: [createPlugin],
+        plugins: [createPlugin],
       }}
     >
       {children}

--- a/packages/react-sdk/src/solana/useAccountEffect.test.tsx
+++ b/packages/react-sdk/src/solana/useAccountEffect.test.tsx
@@ -22,7 +22,7 @@ const sharedConfig = {
   wrapper: ({ children }: { children: React.ReactNode }) => (
     <PhantomProvider
       config={{
-        chainPlugins: [mockCreateSolanaPlugin()],
+        plugins: [mockCreateSolanaPlugin()],
       }}
     >
       {children}

--- a/packages/react-sdk/src/solana/useConnect.test.tsx
+++ b/packages/react-sdk/src/solana/useConnect.test.tsx
@@ -7,7 +7,7 @@ import { PhantomProvider } from "../PhantomContext";
 
 const sharedConfig = {
   wrapper: ({ children }: { children: React.ReactNode }) => (
-    <PhantomProvider config={{ chainPlugins: [createSolanaPlugin()] }}>{children}</PhantomProvider>
+    <PhantomProvider config={{ plugins: [createSolanaPlugin()] }}>{children}</PhantomProvider>
   ),
 };
 
@@ -16,7 +16,7 @@ describe("useConnect", () => {
     jest.clearAllMocks();
   });
 
-  it("should throw error when solana chain plugin is not properly configured", async () => {
+  it("should throw error when solana plugin is not properly configured", async () => {
     const { result } = renderHook(() => useConnect(), {
       wrapper: ({ children }) => <PhantomProvider config={{}}>{children}</PhantomProvider>,
     });

--- a/packages/react-sdk/src/solana/useDisconnect.test.tsx
+++ b/packages/react-sdk/src/solana/useDisconnect.test.tsx
@@ -7,7 +7,7 @@ import { PhantomProvider } from "../PhantomContext";
 
 const sharedConfig = {
   wrapper: ({ children }: { children: React.ReactNode }) => (
-    <PhantomProvider config={{ chainPlugins: [createSolanaPlugin()] }}>{children}</PhantomProvider>
+    <PhantomProvider config={{ plugins: [createSolanaPlugin()] }}>{children}</PhantomProvider>
   ),
 };
 
@@ -16,7 +16,7 @@ describe("useDisconnect", () => {
     jest.clearAllMocks();
   });
 
-  it("should throw error when solana chain plugin is not properly configured", async () => {
+  it("should throw error when solana plugin is not properly configured", async () => {
     const { result } = renderHook(() => useDisconnect(), {
       wrapper: ({ children }) => <PhantomProvider config={{}}>{children}</PhantomProvider>,
     });

--- a/packages/react-sdk/src/solana/useSignAndSendTransaction.test.tsx
+++ b/packages/react-sdk/src/solana/useSignAndSendTransaction.test.tsx
@@ -21,7 +21,7 @@ const sharedConfig = {
   wrapper: ({ children }: { children: React.ReactNode }) => (
     <PhantomProvider
       config={{
-        chainPlugins: [
+        plugins: [
           {
             name: "solana",
             create: () => {
@@ -42,7 +42,7 @@ describe("useSignAndSendTransaction", () => {
     delete window.phantom;
   });
 
-  it("should throw error when solana chain plugin is not properly configured", async () => {
+  it("should throw error when solana plugin is not properly configured", async () => {
     const { result } = renderHook(() => useSignAndSendTransaction(), {
       wrapper: ({ children }) => <PhantomProvider config={{}}>{children}</PhantomProvider>,
     });

--- a/packages/react-sdk/src/solana/useSignIn.test.tsx
+++ b/packages/react-sdk/src/solana/useSignIn.test.tsx
@@ -7,7 +7,7 @@ import type { SolanaSignInData } from "@phantom/browser-sdk/solana";
 
 const sharedConfig = {
   wrapper: ({ children }: { children: React.ReactNode }) => (
-    <PhantomProvider config={{ chainPlugins: [createSolanaPlugin()] }}>{children}</PhantomProvider>
+    <PhantomProvider config={{ plugins: [createSolanaPlugin()] }}>{children}</PhantomProvider>
   ),
 };
 
@@ -23,7 +23,7 @@ describe("useSignIn", () => {
     delete window.phantom;
   });
 
-  it("should throw error when solana chain plugin is not properly configured", async () => {
+  it("should throw error when solana plugin is not properly configured", async () => {
     const { result } = renderHook(() => useSignIn(), {
       wrapper: ({ children }) => <PhantomProvider config={{}}>{children}</PhantomProvider>,
     });

--- a/packages/react-sdk/src/solana/useSignMessage.test.tsx
+++ b/packages/react-sdk/src/solana/useSignMessage.test.tsx
@@ -6,7 +6,7 @@ import { PhantomProvider } from "../PhantomContext";
 
 const sharedConfig = {
   wrapper: ({ children }: { children: React.ReactNode }) => (
-    <PhantomProvider config={{ chainPlugins: [createSolanaPlugin()] }}>{children}</PhantomProvider>
+    <PhantomProvider config={{ plugins: [createSolanaPlugin()] }}>{children}</PhantomProvider>
   ),
 };
 
@@ -22,7 +22,7 @@ describe("useSignMessage", () => {
     delete window.phantom;
   });
 
-  it("should throw error when solana chain plugin is not properly configured", async () => {
+  it("should throw error when solana plugin is not properly configured", async () => {
     const { result } = renderHook(() => useSignMessage(), {
       wrapper: ({ children }) => <PhantomProvider config={{}}>{children}</PhantomProvider>,
     });


### PR DESCRIPTION
This PR simply renames chainPlugins to be just plugins to make it broader for adding plugins that are not necessarily chain related