### PR TITLE
feat: Add support for x-phantom-stamp

### DIFF
--- a/.changeset/two-lizards-destroy.md
+++ b/.changeset/two-lizards-destroy.md
@@ -1,0 +1,5 @@
+---
+"@phantom/server-sdk": patch
+---
+
+feat: Update authentication to use a PKI stamp instead of a signature header

--- a/packages/server-sdk/src/auth.ts
+++ b/packages/server-sdk/src/auth.ts
@@ -14,7 +14,16 @@ export function createAuthenticatedAxiosInstance(signingKeypair: nacl.SignKeyPai
     const dataUtf8 = Buffer.from(requestBody, "utf8");
     const signature = nacl.sign.detached(dataUtf8, signingKeypair.secretKey);
 
-    config.headers["X-Phantom-Sig"] = Buffer.from(signature).toString("base64url");
+    // Create the stamp object
+    const stamp = {
+      kind: "PKI",
+      publicKey: Buffer.from(signingKeypair.publicKey).toString("base64url"),
+      signature: Buffer.from(signature).toString("base64url"),
+    };
+
+    // Encode the stamp as base64url
+    const stampB64 = Buffer.from(JSON.stringify(stamp)).toString("base64url");
+    config.headers["X-Phantom-Stamp"] = stampB64;
 
     return config;
   });


### PR DESCRIPTION
… header

- Replaced the "X-Phantom-Sig" header with "X-Phantom-Stamp" that includes a PKI object containing the public key and signature.
- Updated tests to verify the new stamp structure and ensure the public key and signature are correctly validated.