### PR TITLE
feat: Use phantom wallet stamper to connect your phantom wallet

### DIFF
--- a/examples/browser-embedded-sdk-demo-app/src/components/PhantomWallet.tsx
+++ b/examples/browser-embedded-sdk-demo-app/src/components/PhantomWallet.tsx
@@ -68,6 +68,7 @@ export function PhantomWallet() {
     }
   };
 
+
   const handleNavigateBack = () => {
     setCurrentScreen("navigation");
   };

--- a/examples/browser-sdk-demo-app/index.html
+++ b/examples/browser-sdk-demo-app/index.html
@@ -29,6 +29,13 @@
                 <option value="kit">@solana/kit</option>
               </select>
             </div>
+
+            <div class="form-group">
+              <label class="checkbox-label">
+                <input type="checkbox" id="externalWalletAuth" /> Use External Wallet Authentication
+              </label>
+              <small class="help-text">Connect with Phantom browser extension for authentication</small>
+            </div>
           </div>
 
           <div class="section">

--- a/examples/browser-sdk-demo-app/src/main.ts
+++ b/examples/browser-sdk-demo-app/src/main.ts
@@ -55,6 +55,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // Get configuration UI elements
   const providerTypeSelect = document.getElementById("providerType") as HTMLSelectElement;
   const solanaProviderSelect = document.getElementById("solanaProvider") as HTMLSelectElement;
+  const externalWalletAuthCheckbox = document.getElementById("externalWalletAuth") as HTMLInputElement;
   const testWeb3jsBtn = document.getElementById("testWeb3jsBtn") as HTMLButtonElement;
   const testKitBtn = document.getElementById("testKitBtn") as HTMLButtonElement;
   const testEthereumBtn = document.getElementById("testEthereumBtn") as HTMLButtonElement;
@@ -268,7 +269,18 @@ document.addEventListener("DOMContentLoaded", () => {
     connectBtn.onclick = async () => {
       try {
         sdk = createSDK();
-        const result = await sdk.connect();
+        
+        // Check if external wallet authentication is selected
+        const useExternalWallet = externalWalletAuthCheckbox?.checked || false;
+        const connectOptions = {
+          embeddedWalletType: useExternalWallet ?  "app-wallet": "user-wallet",
+          authOptions: useExternalWallet ? {
+            provider: "external_wallet" as const,
+          }: undefined
+        }
+        
+        console.log("Connecting with options:", connectOptions);
+        const result = await sdk.connect(connectOptions);
         connectedAddresses = result.addresses;
 
         console.log("Connected successfully:", result);
@@ -547,6 +559,30 @@ document.addEventListener("DOMContentLoaded", () => {
       }
     };
   }
+
+  // Update external wallet auth visibility based on provider type
+  function updateExternalWalletVisibility() {
+    if (externalWalletAuthCheckbox) {
+      const parentDiv = externalWalletAuthCheckbox.closest('.form-group') as HTMLDivElement;
+      if (parentDiv) {
+        const isEmbedded = providerTypeSelect.value === "embedded";
+        parentDiv.style.display = isEmbedded ? "block" : "none";
+        if (!isEmbedded) {
+          externalWalletAuthCheckbox.checked = false;
+        }
+      }
+    }
+  }
+
+  // Provider type change handler
+  if (providerTypeSelect) {
+    providerTypeSelect.onchange = () => {
+      updateExternalWalletVisibility();
+    };
+  }
+
+  // Initialize external wallet visibility
+  updateExternalWalletVisibility();
 
   // Initialize button states
   updateButtonStates(false);

--- a/examples/browser-sdk-demo-app/src/style.css
+++ b/examples/browser-sdk-demo-app/src/style.css
@@ -122,6 +122,13 @@ h3 {
   margin: 0;
 }
 
+.help-text {
+  display: block;
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-top: 0.25rem;
+}
+
 /* Button Styles */
 button {
   padding: 0.625rem 1rem;

--- a/packages/client/src/PhantomClient.ts
+++ b/packages/client/src/PhantomClient.ts
@@ -47,6 +47,7 @@ import {
   type CreateAuthenticatorParams,
   type DeleteAuthenticatorParams,
   type UserConfig,
+  type GetOrCreatePhantomOrganizationParams,
 } from "./types";
 
 import type { Stamper } from "@phantom/sdk-types";
@@ -437,6 +438,29 @@ export class PhantomClient {
   }
 
   /**
+   * Get or create a Phantom organization using an external wallet public key
+   * This method is used for external wallet integration (e.g., browser extension)
+   */
+  async getOrCreatePhantomOrganization(params: GetOrCreatePhantomOrganizationParams): Promise<ExternalKmsOrganization> {
+    try {
+      const request = {
+        method: 'getOrCreatePhantomOrganization',
+        params: {
+          publicKey: params.publicKey
+        },
+        timestampMs: Date.now(),
+      };
+
+      const response = await this.kmsApi.postKmsRpc(request as any);
+      const result = response.data.result as ExternalKmsOrganization;
+      return result;
+    } catch (error: any) {
+      console.error("Failed to get or create Phantom organization:", error.response?.data || error.message);
+      throw new Error(`Failed to get or create Phantom organization: ${error.response?.data?.message || error.message}`);
+    }
+  }
+
+  /**
    * Create an authenticator for a user in an organization
    */
   async createAuthenticator(params: CreateAuthenticatorParams): Promise<any> {
@@ -534,6 +558,22 @@ export class PhantomClient {
     } catch (error: any) {
       console.error("Failed to get wallet with tag:", error.response?.data || error.message);
       throw new Error(`Failed to get wallet with tag: ${error.response?.data?.message || error.message}`);
+    }
+  }
+
+  /**
+   * Get a wallet by tag, or create one if it doesn't exist
+   * This is useful for external wallet integration where we want a consistent wallet for a specific tag
+   */
+  async getOrCreateWalletWithTag(params: GetWalletWithTagParams & { walletName?: string }): Promise<any> {
+    try {
+      // First try to get the wallet with the tag
+      return await this.getWalletWithTag(params);
+    } catch (error: any) {
+      // If wallet doesn't exist, create a new one with the tag as the name
+      // Wallet with tag not found, creating new wallet
+      const walletName = params.walletName || params.tag;
+      return await this.createWallet(walletName);
     }
   }
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -87,3 +87,7 @@ export interface UserConfig {
   role?: "admin" | "user"; // Optional, defaults to 'admin'
   authenticators: AuthenticatorConfig[];
 }
+
+export interface GetOrCreatePhantomOrganizationParams {
+  publicKey: string; // base58 encoded public key from external wallet
+}

--- a/packages/embedded-provider-core/package.json
+++ b/packages/embedded-provider-core/package.json
@@ -44,6 +44,7 @@
     "@phantom/client": "workspace:^",
     "@phantom/constants": "workspace:^",
     "@phantom/parsers": "workspace:^",
+    "@phantom/phantom-wallet-stamper": "workspace:^",
     "@phantom/sdk-types": "workspace:^",
     "bs58": "^6.0.0"
   },

--- a/packages/embedded-provider-core/src/embedded-provider.test.ts
+++ b/packages/embedded-provider-core/src/embedded-provider.test.ts
@@ -354,7 +354,7 @@ describe("EmbeddedProvider Core", () => {
       };
 
       await expect(provider.connect(invalidAuthOptions)).rejects.toThrow(
-        'Invalid auth provider: invalid-provider. Must be "google", "apple", or "jwt"',
+        'Invalid auth provider: invalid-provider. Must be "google", "apple", "jwt", or "external_wallet"',
       );
     });
   });

--- a/packages/embedded-provider-core/src/external-wallet-auth-flow.test.ts
+++ b/packages/embedded-provider-core/src/external-wallet-auth-flow.test.ts
@@ -1,0 +1,516 @@
+import { EmbeddedProvider } from "./embedded-provider";
+import type { EmbeddedProviderConfig } from "./types";
+import type {
+  PlatformAdapter,
+  DebugLogger,
+  Session,
+  EmbeddedStorage,
+  AuthProvider,
+  URLParamsAccessor,
+} from "./interfaces";
+import type { StamperWithKeyManagement } from "@phantom/sdk-types";
+import { PhantomClient } from "@phantom/client";
+import { PhantomWalletStamper } from "@phantom/phantom-wallet-stamper";
+
+// Mock dependencies
+jest.mock("@phantom/client");
+jest.mock("@phantom/phantom-wallet-stamper");
+
+// Cast mocked classes for type safety
+const mockedPhantomClient = jest.mocked(PhantomClient);
+const mockedPhantomWalletStamper = jest.mocked(PhantomWalletStamper);
+
+describe("EmbeddedProvider External Wallet Auth Flow", () => {
+  let provider: EmbeddedProvider;
+  let config: EmbeddedProviderConfig;
+  let mockPlatform: PlatformAdapter;
+  let mockLogger: DebugLogger;
+  let mockStorage: jest.Mocked<EmbeddedStorage>;
+  let mockAuthProvider: jest.Mocked<AuthProvider>;
+  let mockURLParamsAccessor: jest.Mocked<URLParamsAccessor>;
+  let mockLocalStamper: jest.Mocked<StamperWithKeyManagement>;
+  let mockPhantomClient: jest.Mocked<PhantomClient>;
+  let mockPhantomStamper: jest.Mocked<PhantomWalletStamper>;
+
+  beforeEach(() => {
+    // Reset mocks
+    jest.clearAllMocks();
+
+    // Setup config for user-wallet with external wallet auth
+    config = {
+      apiBaseUrl: "https://api.example.com",
+      organizationId: "test-org-id",
+      embeddedWalletType: "user-wallet", // user-wallet type to enable auth routing
+      addressTypes: ["solana", "ethereum"],
+      solanaProvider: "web3js",
+    };
+
+    // Mock storage
+    mockStorage = {
+      getSession: jest.fn(),
+      saveSession: jest.fn(),
+      clearSession: jest.fn(),
+    };
+
+    // Mock auth provider (not used for external wallet)
+    mockAuthProvider = {
+      authenticate: jest.fn(),
+      resumeAuthFromRedirect: jest.fn(),
+    };
+
+    // Mock URL params accessor
+    mockURLParamsAccessor = {
+      getParam: jest.fn().mockReturnValue(null),
+    };
+
+    // Mock local platform stamper (e.g., IndexedDB on browser, SecureStore on React Native)
+    mockLocalStamper = {
+      init: jest.fn().mockResolvedValue({ 
+        keyId: "local-key-id", 
+        publicKey: "22222222222222222222222222222222" 
+      }),
+      sign: jest.fn().mockResolvedValue("local-signature"),
+      stamp: jest.fn().mockResolvedValue("local-stamp"),
+      getKeyInfo: jest.fn().mockReturnValue({ 
+        keyId: "local-key-id", 
+        publicKey: "22222222222222222222222222222222" 
+      }),
+      resetKeyPair: jest.fn().mockResolvedValue({ 
+        keyId: "local-key-id", 
+        publicKey: "22222222222222222222222222222222" 
+      }),
+      clear: jest.fn().mockResolvedValue(undefined),
+      algorithm: "ed25519",
+      type: "PKI",
+    };
+
+    // Setup mock platform adapter
+    mockPlatform = {
+      name: "test-platform",
+      storage: mockStorage,
+      authProvider: mockAuthProvider,
+      urlParamsAccessor: mockURLParamsAccessor,
+      stamper: mockLocalStamper,
+    };
+
+    // Setup mock logger
+    mockLogger = {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      log: jest.fn(),
+    };
+
+    // Mock PhantomClient
+    mockPhantomClient = {
+      createOrganization: jest.fn(),
+      getOrCreatePhantomOrganization: jest.fn(),
+      getOrCreateWalletWithTag: jest.fn(),
+      createAuthenticator: jest.fn(),
+      getWalletAddresses: jest.fn(),
+      signMessage: jest.fn(),
+      signAndSendTransaction: jest.fn(),
+    } as any;
+    mockedPhantomClient.mockImplementation(() => mockPhantomClient);
+
+    // Mock PhantomWalletStamper
+    mockPhantomStamper = {
+      init: jest.fn().mockResolvedValue({
+        keyId: "phantom-key-id",
+        publicKey: "33333333333333333333333333333333"
+      }),
+      stamp: jest.fn().mockResolvedValue("phantom-stamp"),
+      getKeyInfo: jest.fn().mockReturnValue({
+        keyId: "phantom-key-id", 
+        publicKey: "33333333333333333333333333333333"
+      }),
+      disconnect: jest.fn().mockResolvedValue(undefined),
+      algorithm: "ed25519",
+      type: "PKI",
+    } as any;
+    mockedPhantomWalletStamper.mockImplementation(() => mockPhantomStamper);
+
+    provider = new EmbeddedProvider(config, mockPlatform, mockLogger);
+  });
+
+  // Helper function to set up common mocks for external wallet flow
+  const setupExternalWalletMocks = () => {
+    mockStorage.getSession.mockResolvedValue(null);
+    mockAuthProvider.resumeAuthFromRedirect.mockReturnValue(null);
+    
+    // Mock the initial organization creation (from createOrganizationAndStamper)
+    mockPhantomClient.createOrganization.mockResolvedValue({ 
+      organizationId: "temp-org-id" 
+    });
+    // Mock external wallet specific methods
+    mockPhantomClient.getOrCreatePhantomOrganization.mockResolvedValue({ 
+      organizationId: "phantom-org-id" 
+    });
+    mockPhantomClient.getOrCreateWalletWithTag.mockResolvedValue({ 
+      walletId: "external-wallet-123" 
+    });
+    mockPhantomClient.createAuthenticator.mockResolvedValue({ success: true });
+    mockPhantomClient.getWalletAddresses.mockResolvedValue([
+      { addressType: "solana", address: "phantom-solana-address" }
+    ]);
+  };
+
+  describe("External Wallet Connection Flow", () => {
+    it("should connect to Phantom wallet when authOptions.provider is external_wallet", async () => {
+      setupExternalWalletMocks();
+
+      const result = await provider.connect({ provider: "external_wallet" });
+
+      expect(PhantomWalletStamper).toHaveBeenCalledWith({
+        platform: "auto",
+        timeout: 30000,
+      });
+      expect(mockPhantomStamper.init).toHaveBeenCalled();
+      expect(result.walletId).toBe("external-wallet-123");
+      expect(result.status).toBe("completed");
+    });
+
+    it("should get or create Phantom organization using external wallet public key", async () => {
+      setupExternalWalletMocks();
+
+      await provider.connect({ provider: "external_wallet" });
+
+      expect(mockPhantomClient.getOrCreatePhantomOrganization).toHaveBeenCalledWith({
+        publicKey: expect.any(String), // base64url encoded phantom public key
+      });
+    });
+
+    it("should get or create wallet with tag using Phantom organization", async () => {
+      setupExternalWalletMocks();
+
+      await provider.connect({ provider: "external_wallet" });
+
+      expect(mockPhantomClient.getOrCreateWalletWithTag).toHaveBeenCalledWith({
+        organizationId: "phantom-org-id",
+        tag: "external-wallet-33333333",
+        derivationPaths: [
+          "m/44'/501'/0'/0'", // Solana
+          "m/44'/60'/0'/0/0", // Ethereum
+          "m/84'/0'/0'/0/0",  // Bitcoin
+        ],
+        walletName: "External Wallet 33333333",
+      });
+    });
+
+    it("should initialize local platform stamper for subsequent operations", async () => {
+      setupExternalWalletMocks();
+
+      await provider.connect({ provider: "external_wallet" });
+
+      expect(mockLocalStamper.init).toHaveBeenCalled();
+    });
+
+    it("should add local stamper as authenticator to Phantom organization", async () => {
+      setupExternalWalletMocks();
+
+      await provider.connect({ provider: "external_wallet" });
+
+      expect(mockPhantomClient.createAuthenticator).toHaveBeenCalledWith({
+        organizationId: "phantom-org-id",
+        username: "user-phantom-33333333",
+        authenticatorName: "local-local-key-id",
+        authenticator: {
+          authenticatorName: "local-local-key-id",
+          authenticatorKind: "keypair",
+          publicKey: expect.any(String), // base64url encoded local public key
+          algorithm: "Ed25519",
+        },
+      });
+    });
+
+    it("should save completed session with external wallet details", async () => {
+      setupExternalWalletMocks();
+
+      await provider.connect({ provider: "external_wallet" });
+
+      expect(mockStorage.saveSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          walletId: "external-wallet-123",
+          organizationId: "phantom-org-id",
+          stamperInfo: {
+            keyId: "local-key-id",
+            publicKey: "22222222222222222222222222222222",
+          },
+          authProvider: "external-wallet",
+          userInfo: {
+            embeddedWalletType: "app-wallet",
+            authProvider: "external_wallet",
+            phantomPublicKey: "33333333333333333333333333333333",
+          },
+          status: "completed",
+        }),
+      );
+    });
+
+    it("should use local stamper for subsequent operations after external wallet setup", async () => {
+      setupExternalWalletMocks();
+      // Override the default mock to return addresses
+      mockPhantomClient.getWalletAddresses.mockResolvedValue([
+        { addressType: "solana", address: "test-solana-address" }
+      ]);
+
+      const result = await provider.connect({ provider: "external_wallet" });
+
+      // PhantomClient should be called for the final client setup
+      expect(PhantomClient).toHaveBeenCalled();
+      expect(result.addresses).toHaveLength(1);
+    });
+  });
+
+  describe("External Wallet Error Handling", () => {
+    it("should handle Phantom wallet not available error", async () => {
+      mockStorage.getSession.mockResolvedValue(null);
+      mockAuthProvider.resumeAuthFromRedirect.mockReturnValue(null);
+      mockPhantomClient.createOrganization.mockResolvedValue({ organizationId: "temp-org-id" });
+      mockPhantomStamper.init.mockRejectedValue(new Error("Phantom wallet extension not found"));
+
+      await expect(provider.connect({ provider: "external_wallet" })).rejects.toThrow(/Phantom wallet/);
+    });
+
+    it("should handle organization creation failure", async () => {
+      mockStorage.getSession.mockResolvedValue(null);
+      mockAuthProvider.resumeAuthFromRedirect.mockReturnValue(null);
+      mockPhantomClient.createOrganization.mockResolvedValue({ organizationId: "temp-org-id" });
+      mockPhantomClient.getOrCreatePhantomOrganization.mockRejectedValue(
+        new Error("Failed to create Phantom organization")
+      );
+
+      await expect(provider.connect({ provider: "external_wallet" })).rejects.toThrow(/organization/);
+    });
+
+    it("should handle wallet creation failure", async () => {
+      mockStorage.getSession.mockResolvedValue(null);
+      mockAuthProvider.resumeAuthFromRedirect.mockReturnValue(null);
+      mockPhantomClient.createOrganization.mockResolvedValue({ organizationId: "temp-org-id" });
+      mockPhantomClient.getOrCreatePhantomOrganization.mockResolvedValue({ organizationId: "phantom-org-id" });
+      mockPhantomClient.getOrCreateWalletWithTag.mockRejectedValue(
+        new Error("Failed to create external wallet")
+      );
+
+      await expect(provider.connect({ provider: "external_wallet" })).rejects.toThrow(/wallet/);
+    });
+
+    it("should handle local stamper initialization failure", async () => {
+      mockStorage.getSession.mockResolvedValue(null);
+      mockAuthProvider.resumeAuthFromRedirect.mockReturnValue(null);
+      mockPhantomClient.createOrganization.mockResolvedValue({ organizationId: "temp-org-id" });
+      mockPhantomClient.getOrCreatePhantomOrganization.mockResolvedValue({ organizationId: "phantom-org-id" });
+      mockPhantomClient.getOrCreateWalletWithTag.mockResolvedValue({ walletId: "external-wallet-123" });
+      mockLocalStamper.init.mockRejectedValue(new Error("Storage not available"));
+
+      await expect(provider.connect({ provider: "external_wallet" })).rejects.toThrow(/Storage/);
+    });
+
+    it("should handle authenticator creation failure", async () => {
+      mockStorage.getSession.mockResolvedValue(null);
+      mockAuthProvider.resumeAuthFromRedirect.mockReturnValue(null);
+      mockPhantomClient.createOrganization.mockResolvedValue({ organizationId: "temp-org-id" });
+      mockPhantomClient.getOrCreatePhantomOrganization.mockResolvedValue({ organizationId: "phantom-org-id" });
+      mockPhantomClient.getOrCreateWalletWithTag.mockResolvedValue({ walletId: "external-wallet-123" });
+      mockPhantomClient.createAuthenticator.mockRejectedValue(
+        new Error("Failed to add authenticator")
+      );
+
+      await expect(provider.connect({ provider: "external_wallet" })).rejects.toThrow(/authenticator/);
+    });
+  });
+
+  describe("External Wallet Session Management", () => {
+    it("should resume external wallet session if already connected", async () => {
+      const existingSession: Session = {
+        sessionId: "external-session-id",
+        walletId: "external-wallet-123",
+        organizationId: "phantom-org-id",
+        stamperInfo: {
+          keyId: "local-key-id",
+          publicKey: "22222222222222222222222222222222",
+        },
+        authProvider: "external-wallet",
+        userInfo: {
+          embeddedWalletType: "app-wallet",
+          authProvider: "external_wallet",
+          phantomPublicKey: "33333333333333333333333333333333",
+        },
+        status: "completed",
+        createdAt: Date.now(),
+        lastUsed: Date.now(),
+      };
+      
+      mockStorage.getSession.mockResolvedValue(existingSession);
+      mockAuthProvider.resumeAuthFromRedirect.mockReturnValue(null);
+      mockPhantomClient.getWalletAddresses.mockResolvedValue([
+        { addressType: "solana", address: "test-solana-address" }
+      ]);
+
+      const result = await provider.connect();
+
+      // Should not recreate external wallet connection
+      expect(PhantomWalletStamper).not.toHaveBeenCalled();
+      expect(result.walletId).toBe("external-wallet-123");
+      expect(result.status).toBe("completed");
+    });
+
+    it("should update session timestamp when resuming external wallet", async () => {
+      const existingSession: Session = {
+        sessionId: "external-session-id",
+        walletId: "external-wallet-123",
+        organizationId: "phantom-org-id",
+        stamperInfo: {
+          keyId: "local-key-id",
+          publicKey: "22222222222222222222222222222222",
+        },
+        authProvider: "external-wallet",
+        userInfo: {
+          embeddedWalletType: "app-wallet",
+          authProvider: "external_wallet",
+          phantomPublicKey: "33333333333333333333333333333333",
+        },
+        status: "completed",
+        createdAt: Date.now(),
+        lastUsed: Date.now() - 60000, // 1 minute ago
+      };
+      
+      mockStorage.getSession.mockResolvedValue(existingSession);
+      mockAuthProvider.resumeAuthFromRedirect.mockReturnValue(null);
+      mockPhantomClient.getWalletAddresses.mockResolvedValue([]);
+
+      const originalLastUsed = existingSession.lastUsed;
+      await provider.connect({ provider: "external_wallet" });
+
+      // Session timestamp should be updated for external wallet auth
+      expect(mockStorage.saveSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lastUsed: expect.any(Number),
+        }),
+      );
+      
+      const savedSession = mockStorage.saveSession.mock.calls[0][0];
+      expect(savedSession.lastUsed).toBeGreaterThan(originalLastUsed);
+    });
+
+    it("should disconnect external wallet and clear session", async () => {
+      // Set up connected state
+      const existingSession: Session = {
+        sessionId: "external-session-id",
+        walletId: "external-wallet-123",
+        organizationId: "phantom-org-id",
+        stamperInfo: {
+          keyId: "local-key-id",
+          publicKey: "22222222222222222222222222222222",
+        },
+        authProvider: "external-wallet",
+        userInfo: {
+          embeddedWalletType: "app-wallet",
+          authProvider: "external_wallet",
+          phantomPublicKey: "33333333333333333333333333333333",
+        },
+        status: "completed",
+        createdAt: Date.now(),
+        lastUsed: Date.now(),
+      };
+      
+      mockStorage.getSession.mockResolvedValue(existingSession);
+      mockAuthProvider.resumeAuthFromRedirect.mockReturnValue(null);
+      mockPhantomClient.getWalletAddresses.mockResolvedValue([]);
+
+      await provider.connect({ provider: "external_wallet" });
+      expect(provider.isConnected()).toBe(true);
+
+      await provider.disconnect();
+
+      expect(mockStorage.clearSession).toHaveBeenCalled();
+      expect(provider.isConnected()).toBe(false);
+    });
+  });
+
+  describe("External Wallet Operations", () => {
+    beforeEach(async () => {
+      // Set up connected external wallet state
+      setupExternalWalletMocks();
+      mockPhantomClient.getWalletAddresses.mockResolvedValue([
+        { addressType: "solana", address: "external-solana-address" }
+      ]);
+
+      await provider.connect({ provider: "external_wallet" });
+    });
+
+    it("should sign messages using local stamper after external wallet setup", async () => {
+      mockPhantomClient.signMessage.mockResolvedValue("external-message-signature");
+
+      await provider.signMessage({
+        message: "test message",
+        networkId: "solana:mainnet",
+      });
+
+      expect(mockPhantomClient.signMessage).toHaveBeenCalledWith({
+        walletId: "external-wallet-123",
+        message: expect.any(String),
+        networkId: "solana:mainnet",
+      });
+    });
+
+    it("should sign and send transactions using local stamper after external wallet setup", async () => {
+      mockPhantomClient.signAndSendTransaction.mockResolvedValue({
+        rawTransaction: "base64url-raw-transaction",
+        hash: "transaction-hash",
+      });
+
+      await provider.signAndSendTransaction({
+        transaction: "base64-encoded-transaction",
+        networkId: "solana:mainnet",
+      });
+
+      expect(mockPhantomClient.signAndSendTransaction).toHaveBeenCalledWith({
+        walletId: "external-wallet-123",
+        transaction: expect.any(String),
+        networkId: "solana:mainnet",
+      });
+    });
+
+    it("should return addresses from external wallet", () => {
+      const addresses = provider.getAddresses();
+      
+      expect(addresses).toHaveLength(1);
+      expect(addresses[0]).toEqual({
+        addressType: "solana",
+        address: "external-solana-address",
+      });
+    });
+  });
+
+  describe("External Wallet Integration Points", () => {
+    it("should create unique wallet tags based on Phantom public key", async () => {
+      setupExternalWalletMocks();
+
+      await provider.connect({ provider: "external_wallet" });
+
+      const getOrCreateCall = mockPhantomClient.getOrCreateWalletWithTag.mock.calls[0][0];
+      expect(getOrCreateCall.tag).toMatch(/^external-wallet-[a-f0-9]{8}$/);
+      expect(getOrCreateCall.walletName).toMatch(/^External Wallet [a-f0-9]{8}$/);
+    });
+
+    it("should create unique authenticator names based on local stamper key ID", async () => {
+      setupExternalWalletMocks();
+
+      await provider.connect({ provider: "external_wallet" });
+
+      const createAuthCall = mockPhantomClient.createAuthenticator.mock.calls[0][0];
+      expect(createAuthCall.authenticatorName).toBe("local-local-key-id");
+      expect(createAuthCall.authenticator.authenticatorName).toBe("local-local-key-id");
+    });
+
+    it("should store phantom public key in session for reference", async () => {
+      setupExternalWalletMocks();
+
+      await provider.connect({ provider: "external_wallet" });
+
+      const saveSessionCall = mockStorage.saveSession.mock.calls[0][0];
+      expect(saveSessionCall.userInfo.phantomPublicKey).toBe("33333333333333333333333333333333");
+    });
+  });
+});

--- a/packages/embedded-provider-core/src/types.ts
+++ b/packages/embedded-provider-core/src/types.ts
@@ -30,7 +30,7 @@ export interface SignAndSendTransactionParams {
 export interface SignedTransaction extends ParsedTransactionResult {}
 
 export interface AuthOptions {
-  provider?: "google" | "apple" | "jwt";
+  provider?: "google" | "apple" | "jwt" | "external_wallet";
   jwtToken?: string;
   customAuthData?: Record<string, any>;
 }

--- a/packages/phantom-wallet-stamper/.eslintignore
+++ b/packages/phantom-wallet-stamper/.eslintignore
@@ -1,0 +1,11 @@
+node_modules
+.eslintrc.js
+dist/
+**/dist/
+**/node_modules/
+/**/node_modules/*
+build/
+**/build/
+*.js
+*.d.ts
+tsup.config.ts

--- a/packages/phantom-wallet-stamper/README.md
+++ b/packages/phantom-wallet-stamper/README.md
@@ -1,0 +1,120 @@
+# @phantom/phantom-wallet-stamper
+
+A stamper implementation for integrating with external Phantom wallets (browser extension and mobile app).
+
+## Overview
+
+The PhantomWalletStamper allows you to connect to an external Phantom wallet and use it to sign requests for authentication with the Phantom KMS API. This is useful for scenarios where you want to:
+
+1. Connect to a user's existing Phantom wallet (browser extension or mobile app)
+2. Use the wallet's private key to stamp/authenticate API requests
+3. Create a local organization tied to that external wallet
+4. Generate a local keypair for subsequent operations
+
+## Installation
+
+```bash
+npm install @phantom/phantom-wallet-stamper
+```
+
+## Usage
+
+### Browser (Extension) Integration
+
+```typescript
+import { PhantomWalletStamper } from '@phantom/phantom-wallet-stamper';
+import { PhantomClient } from '@phantom/client';
+
+// Create the stamper
+const stamper = new PhantomWalletStamper({
+  platform: 'browser', // or 'auto' to detect automatically
+  timeout: 30000 // 30 second timeout
+});
+
+// Initialize and connect to Phantom wallet
+const stamperInfo = await stamper.init();
+console.log('Connected to wallet:', stamperInfo.publicKey);
+
+// Use with PhantomClient to create organization
+const client = new PhantomClient({ apiBaseUrl: 'your-api-url' }, stamper);
+
+// Get or create organization using external wallet
+const organization = await client.getOrCreatePhantomOrganization({
+  publicKey: stamperInfo.publicKey
+});
+
+// Now create a local wallet with a fixed tag
+const wallet = await client.getOrCreateWalletWithTag({
+  organizationId: organization.organizationId,
+  tag: 'solana-account',
+  derivationPaths: ['m/44\'/501\'/0\'/0\''] // Solana path
+});
+```
+
+### Mobile Integration
+
+Mobile integration uses deep links to connect to the Phantom mobile app:
+
+```typescript
+const stamper = new PhantomWalletStamper({
+  platform: 'mobile'
+});
+
+try {
+  await stamper.init(); // Will open phantom://connect deep link
+} catch (error) {
+  // Mobile implementation requires additional callback handling
+  console.error('Mobile connection not yet fully implemented');
+}
+```
+
+### Configuration
+
+```typescript
+interface PhantomWalletStamperConfig {
+  platform?: 'browser' | 'mobile' | 'auto'; // Default: 'auto'
+  timeout?: number; // Connection timeout in ms, default: 30000
+}
+```
+
+## API Reference
+
+### PhantomWalletStamper
+
+#### Methods
+
+- `init()`: Initialize and connect to the Phantom wallet
+- `stamp(data: { data: Uint8Array })`: Sign data with the external wallet's private key
+- `getKeyInfo()`: Get information about the connected wallet's key
+- `signTransaction(transaction: Uint8Array)`: Sign a transaction with the external wallet
+- `disconnect()`: Disconnect from the external wallet
+
+#### Properties
+
+- `algorithm`: Always "Ed25519" for Solana compatibility
+
+## Platform Detection
+
+The stamper automatically detects the platform:
+
+- **Browser**: Checks for `window.phantom.solana` presence
+- **Mobile**: Detects mobile user agents and uses deep links
+- **Auto**: Automatically chooses the appropriate method
+
+## Error Handling
+
+Common errors and solutions:
+
+- `"Phantom wallet extension not found"`: Install the Phantom browser extension
+- `"Connection to Phantom wallet timed out"`: Increase timeout or check wallet availability
+- `"Mobile deep linking not supported"`: Mobile implementation needs additional work
+
+## Integration Flow
+
+1. **Connect**: Use PhantomWalletStamper to connect to external wallet
+2. **Authenticate**: Stamp requests with external wallet's private key
+3. **Create Organization**: Call `getOrCreatePhantomOrganization` with external public key
+4. **Create Local Wallet**: Use `getOrCreateWalletWithTag` for consistent wallet management
+5. **Local Operations**: Switch to local keypair (IndexedDBStamper) for subsequent requests
+
+This stamper is designed to work seamlessly with the existing Phantom SDK architecture while providing external wallet integration capabilities.

--- a/packages/phantom-wallet-stamper/jest.config.js
+++ b/packages/phantom-wallet-stamper/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/*.test.ts"],
+  collectCoverageFrom: ["src/**/*.ts", "!src/**/*.d.ts"],
+};

--- a/packages/phantom-wallet-stamper/package.json
+++ b/packages/phantom-wallet-stamper/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@phantom/phantom-wallet-stamper",
+  "version": "0.1.0",
+  "description": "Stamper for external Phantom wallet integration",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "?pack-release": "When https://github.com/changesets/changesets/issues/432 has a solution we can remove this trick",
+    "pack-release": "rimraf ./_release && yarn pack && mkdir ./_release && tar zxvf ./package.tgz --directory ./_release && rm ./package.tgz",
+    "build": "rimraf ./dist && tsup src/index.ts --format cjs,esm --dts --external buffer,@phantom/base64url,@phantom/sdk-types",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "lint": "tsc --noEmit && eslint --cache . --ext .ts,.tsx",
+    "check-types": "tsc --noEmit",
+    "prettier": "prettier --write \"src/**/*.{ts,tsx}\""
+  },
+  "dependencies": {
+    "@phantom/base64url": "workspace:*",
+    "@phantom/sdk-types": "workspace:*",
+    "bs58": "^6.0.0",
+    "buffer": "^6.0.3"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.0",
+    "eslint": "8.53.0",
+    "jest": "^29.7.0",
+    "prettier": "^3.5.2",
+    "rimraf": "^6.0.1",
+    "ts-jest": "^29.1.2",
+    "tsup": "^7.2.0",
+    "typescript": "^5.0.4"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "directory": "_release/package"
+  }
+}

--- a/packages/phantom-wallet-stamper/src/index.test.ts
+++ b/packages/phantom-wallet-stamper/src/index.test.ts
@@ -1,0 +1,220 @@
+import { PhantomWalletStamper } from './index';
+import { Buffer } from 'buffer';
+
+// Mock window.phantom.solana
+const mockPhantom = {
+  connect: jest.fn(),
+  signTransaction: jest.fn(),
+  signMessage: jest.fn(),
+  disconnect: jest.fn(),
+  isConnected: false,
+  publicKey: undefined,
+};
+
+// Setup global mocks - use configurable to allow deletion
+Object.defineProperty(window, 'phantom', {
+  value: {
+    solana: mockPhantom,
+  },
+  writable: true,
+  configurable: true,
+});
+
+describe('PhantomWalletStamper', () => {
+  let stamper: PhantomWalletStamper;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stamper = new PhantomWalletStamper();
+  });
+
+  afterEach(async () => {
+    try {
+      await stamper.disconnect();
+    } catch {
+      // Ignore errors in cleanup
+    }
+  });
+
+  describe('constructor', () => {
+    it('should create with default config', () => {
+      const stamper = new PhantomWalletStamper();
+      expect(stamper.algorithm).toBe('Ed25519');
+    });
+
+    it('should create with custom config', () => {
+      const stamper = new PhantomWalletStamper({
+        platform: 'browser',
+        timeout: 5000,
+      });
+      expect(stamper.algorithm).toBe('Ed25519');
+    });
+  });
+
+  describe('platform detection', () => {
+    it('should detect browser platform when phantom is available', () => {
+      const stamper = new PhantomWalletStamper({ platform: 'auto' });
+      // Platform detection is done in init(), so we test indirectly
+      expect(stamper.algorithm).toBe('Ed25519');
+    });
+
+    it('should use explicit platform setting', () => {
+      const stamper = new PhantomWalletStamper({ platform: 'browser' });
+      expect(stamper.algorithm).toBe('Ed25519');
+    });
+  });
+
+  describe('init', () => {
+    it('should successfully initialize with mock phantom wallet', async () => {
+      const mockPublicKey = {
+        toString: () => '11111111111111111111111111111111',
+      };
+      
+      mockPhantom.connect.mockResolvedValue({
+        publicKey: mockPublicKey,
+      });
+
+      const stamperInfo = await stamper.init();
+
+      expect(mockPhantom.connect).toHaveBeenCalled();
+      expect(stamperInfo.publicKey).toBe('11111111111111111111111111111111');
+      expect(stamperInfo.keyId).toContain('phantom-wallet-');
+    });
+
+    it('should throw error if phantom is not available', async () => {
+      // Temporarily remove phantom
+      const originalPhantom = window.phantom;
+      delete (window as any).phantom;
+
+      const stamper = new PhantomWalletStamper({ platform: 'browser' });
+
+      await expect(stamper.init()).rejects.toThrow('Phantom wallet extension not found');
+
+      // Restore phantom
+      window.phantom = originalPhantom;
+    });
+
+    it('should throw error for unsupported mobile platform', async () => {
+      const stamper = new PhantomWalletStamper({ platform: 'mobile' });
+
+      await expect(stamper.init()).rejects.toThrow('Mobile Phantom wallet connection not yet implemented');
+    });
+  });
+
+  describe('stamp', () => {
+    beforeEach(async () => {
+      const mockPublicKey = {
+        toString: () => '11111111111111111111111111111111',
+      };
+      
+      mockPhantom.connect.mockResolvedValue({
+        publicKey: mockPublicKey,
+      });
+
+      await stamper.init();
+    });
+
+    it('should successfully stamp data', async () => {
+      const mockSignature = new Uint8Array([1, 2, 3, 4]);
+      mockPhantom.signMessage.mockResolvedValue({
+        signature: mockSignature,
+      });
+
+      const data = Buffer.from([5, 6, 7, 8]);
+      const stamp = await stamper.stamp({ data });
+
+      expect(mockPhantom.signMessage).toHaveBeenCalledWith(new Uint8Array(data));
+      expect(typeof stamp).toBe('string');
+    });
+
+    it('should throw error if not initialized', async () => {
+      const uninitializedStamper = new PhantomWalletStamper();
+      const data = Buffer.from([1, 2, 3, 4]);
+
+      await expect(uninitializedStamper.stamp({ data })).rejects.toThrow(
+        'PhantomWalletStamper not initialized'
+      );
+    });
+  });
+
+  describe('signTransaction', () => {
+    beforeEach(async () => {
+      const mockPublicKey = {
+        toString: () => '11111111111111111111111111111111',
+      };
+      
+      mockPhantom.connect.mockResolvedValue({
+        publicKey: mockPublicKey,
+      });
+
+      await stamper.init();
+    });
+
+    it('should successfully sign transaction', async () => {
+      const mockSignature = new Uint8Array([1, 2, 3, 4]);
+      mockPhantom.signTransaction.mockResolvedValue({
+        signature: mockSignature,
+      });
+
+      const transaction = new Uint8Array([5, 6, 7, 8]);
+      const signature = await stamper.signTransaction(transaction);
+
+      expect(mockPhantom.signTransaction).toHaveBeenCalledWith(transaction);
+      expect(signature).toEqual(mockSignature);
+    });
+
+    it('should throw error if not initialized', async () => {
+      const uninitializedStamper = new PhantomWalletStamper();
+      const transaction = new Uint8Array([1, 2, 3, 4]);
+
+      await expect(uninitializedStamper.signTransaction(transaction)).rejects.toThrow(
+        'PhantomWalletStamper not initialized'
+      );
+    });
+  });
+
+  describe('getKeyInfo', () => {
+    it('should return null if not initialized', () => {
+      expect(stamper.getKeyInfo()).toBeNull();
+    });
+
+    it('should return stamper info after initialization', async () => {
+      const mockPublicKey = {
+        toString: () => '11111111111111111111111111111111',
+      };
+      
+      mockPhantom.connect.mockResolvedValue({
+        publicKey: mockPublicKey,
+      });
+
+      await stamper.init();
+      const keyInfo = stamper.getKeyInfo();
+
+      expect(keyInfo).not.toBeNull();
+      expect(keyInfo!.publicKey).toBe('11111111111111111111111111111111');
+      expect(keyInfo!.keyId).toContain('phantom-wallet-');
+    });
+  });
+
+  describe('disconnect', () => {
+    it('should successfully disconnect', async () => {
+      const mockPublicKey = {
+        toString: () => '11111111111111111111111111111111',
+      };
+      
+      mockPhantom.connect.mockResolvedValue({
+        publicKey: mockPublicKey,
+      });
+
+      await stamper.init();
+      await stamper.disconnect();
+
+      expect(mockPhantom.disconnect).toHaveBeenCalled();
+      expect(stamper.getKeyInfo()).toBeNull();
+    });
+
+    it('should handle disconnect when not connected', async () => {
+      await expect(stamper.disconnect()).resolves.not.toThrow();
+    });
+  });
+});

--- a/packages/phantom-wallet-stamper/src/index.ts
+++ b/packages/phantom-wallet-stamper/src/index.ts
@@ -1,0 +1,175 @@
+import type { StamperWithKeyManagement, StamperKeyInfo } from "@phantom/sdk-types";
+import { Algorithm } from "@phantom/sdk-types";
+import type { Buffer } from "buffer";
+import { base64urlEncode } from "@phantom/base64url";
+export interface PhantomWalletStamperConfig {
+  platform?: "browser" | "mobile" | "auto";
+  timeout?: number; // Connection timeout in ms
+}
+
+export interface PhantomWalletConnection {
+  publicKey: string; // base58 encoded public key
+  signMessage: (message: Uint8Array) => Promise<Uint8Array>;
+  disconnect: () => Promise<void>;
+}
+
+// Types for window.phantom.solana
+interface PhantomSolanaProvider {
+  connect(): Promise<{ publicKey: { toString(): string } }>;
+  signTransaction(transaction: any): Promise<{ signature: Uint8Array }>;
+  signMessage(message: Uint8Array): Promise<{ signature: Uint8Array }>;
+  disconnect(): Promise<void>;
+  isConnected: boolean;
+  publicKey?: { toString(): string };
+}
+
+declare global {
+  interface Window {
+    phantom?: {
+      solana?: PhantomSolanaProvider;
+    };
+  }
+}
+
+export class PhantomWalletStamper implements StamperWithKeyManagement {
+  public algorithm: Algorithm = Algorithm.ed25519;
+  public type: "PKI" | "OIDC" = "PKI";
+  private config: PhantomWalletStamperConfig;
+  private connection: PhantomWalletConnection | null = null;
+  private stamperInfo: StamperKeyInfo | null = null;
+
+  constructor(config: PhantomWalletStamperConfig = {}) {
+    this.config = {
+      platform: config.platform || "auto",
+      timeout: config.timeout || 30000, // 30 second default timeout
+      ...config,
+    };
+  }
+
+  async init(): Promise<StamperKeyInfo> {
+    const platform = this.detectPlatform();
+    
+    if (platform === "browser") {
+      this.connection = await this.connectBrowser();
+    } else if (platform === "mobile") {
+      this.connection = await this.connectMobile();
+    } else {
+      throw new Error(`Unsupported platform: ${platform}`);
+    }
+
+    this.stamperInfo = {
+      publicKey: this.connection.publicKey, // Keep base58 for external compatibility
+      keyId: `phantom-wallet-${this.connection.publicKey.slice(0, 8)}`,
+    };
+
+    return this.stamperInfo;
+  }
+
+  async stamp(params: { data: Buffer; type?: "PKI"; idToken?: never; salt?: never } | { data: Buffer; type: "OIDC"; idToken: string; salt: string }): Promise<string> {
+    if (!this.connection || !this.stamperInfo) {
+      throw new Error("PhantomWalletStamper not initialized. Call init() first.");
+    }
+
+    try {
+      // Sign the data using the external wallet's private key
+      const signature = await this.connection.signMessage(new Uint8Array(params.data));
+      
+      // Return base64url encoded signature
+      return base64urlEncode(signature);
+    } catch (error) {
+      throw new Error(`Failed to stamp with Phantom wallet: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  getKeyInfo(): StamperKeyInfo | null {
+    return this.stamperInfo;
+  }
+
+
+  async disconnect(): Promise<void> {
+    if (this.connection) {
+      await this.connection.disconnect();
+      this.connection = null;
+      this.stamperInfo = null;
+    }
+  }
+
+  private detectPlatform(): "browser" | "mobile" {
+    if (this.config.platform !== "auto") {
+      return this.config.platform!;
+    }
+
+    // Detect if we're in a browser environment
+    if (typeof window !== "undefined" && window.phantom?.solana) {
+      return "browser";
+    }
+
+    // Detect mobile environment (React Native or mobile browser)
+    if (typeof navigator !== "undefined" && /iPhone|iPad|iPod|Android/i.test(navigator.userAgent)) {
+      return "mobile";
+    }
+
+    // Default to browser if we can't detect
+    return "browser";
+  }
+
+  private async connectBrowser(): Promise<PhantomWalletConnection> {
+    if (typeof window === "undefined" || !window.phantom?.solana) {
+      throw new Error("Phantom wallet extension not found. Please install the Phantom wallet extension.");
+    }
+
+    const phantom = window.phantom.solana;
+    
+    try {
+      // Connect to Phantom wallet
+      const response = await this.withTimeout(
+        phantom.connect(),
+        this.config.timeout!,
+        "Connection to Phantom wallet timed out"
+      );
+
+      const publicKey = response.publicKey.toString();
+      return {
+        publicKey,
+        signMessage: async (message: Uint8Array) => {
+          const result = await phantom.signMessage(message);
+          return result.signature;
+        },
+        disconnect: async () => {
+          await phantom.disconnect();
+        },
+      };
+    } catch (error) {
+      throw new Error(`Failed to connect to Phantom wallet: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private connectMobile(): Promise<PhantomWalletConnection> {
+    // For mobile, we'll use deep links to connect to Phantom
+    const connectUrl = "phantom://connect";
+    
+    try {
+      // Open Phantom app with deep link
+      if (typeof window !== "undefined" && window.location) {
+        window.location.href = connectUrl;
+      } else {
+        throw new Error("Mobile deep linking not supported in this environment");
+      }
+
+      // For now, throw an error as mobile implementation needs more work
+      // This would require a callback mechanism to receive the connection result
+      throw new Error("Mobile Phantom wallet connection not yet implemented. Use browser version instead.");
+      
+    } catch (error) {
+      throw new Error(`Failed to connect to Phantom mobile wallet: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  private async withTimeout<T>(promise: Promise<T>, timeoutMs: number, timeoutMessage: string): Promise<T> {
+    const timeout = new Promise<never>((_, reject) => {
+      setTimeout(() => reject(new Error(timeoutMessage)), timeoutMs);
+    });
+
+    return Promise.race([promise, timeout]);
+  }
+}

--- a/packages/phantom-wallet-stamper/tsconfig.json
+++ b/packages/phantom-wallet-stamper/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@phantom/*": ["../*/src"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["_release", "node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/phantom-wallet-stamper/tsup.config.ts
+++ b/packages/phantom-wallet-stamper/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  external: ["@phantom/sdk-types", "@phantom/base64url", "bs58"],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3255,7 +3255,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@phantom/base64url@workspace:^, @phantom/base64url@workspace:packages/base64url":
+"@phantom/base64url@workspace:*, @phantom/base64url@workspace:^, @phantom/base64url@workspace:packages/base64url":
   version: 0.0.0-use.local
   resolution: "@phantom/base64url@workspace:packages/base64url"
   dependencies:
@@ -3422,6 +3422,7 @@ __metadata:
     "@phantom/client": "workspace:^"
     "@phantom/constants": "workspace:^"
     "@phantom/parsers": "workspace:^"
+    "@phantom/phantom-wallet-stamper": "workspace:^"
     "@phantom/sdk-types": "workspace:^"
     "@types/jest": "npm:^29.5.5"
     "@types/node": "npm:^20.11.0"
@@ -3509,6 +3510,26 @@ __metadata:
       optional: true
     viem:
       optional: true
+  languageName: unknown
+  linkType: soft
+
+"@phantom/phantom-wallet-stamper@workspace:^, @phantom/phantom-wallet-stamper@workspace:packages/phantom-wallet-stamper":
+  version: 0.0.0-use.local
+  resolution: "@phantom/phantom-wallet-stamper@workspace:packages/phantom-wallet-stamper"
+  dependencies:
+    "@phantom/base64url": "workspace:*"
+    "@phantom/sdk-types": "workspace:*"
+    "@types/jest": "npm:^29.5.12"
+    "@types/node": "npm:^20.11.0"
+    bs58: "npm:^6.0.0"
+    buffer: "npm:^6.0.3"
+    eslint: "npm:8.53.0"
+    jest: "npm:^29.7.0"
+    prettier: "npm:^3.5.2"
+    rimraf: "npm:^6.0.1"
+    ts-jest: "npm:^29.1.2"
+    tsup: "npm:^7.2.0"
+    typescript: "npm:^5.0.4"
   languageName: unknown
   linkType: soft
 
@@ -3677,7 +3698,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@phantom/sdk-types@workspace:^, @phantom/sdk-types@workspace:packages/sdk-types":
+"@phantom/sdk-types@workspace:*, @phantom/sdk-types@workspace:^, @phantom/sdk-types@workspace:packages/sdk-types":
   version: 0.0.0-use.local
   resolution: "@phantom/sdk-types@workspace:packages/sdk-types"
   dependencies:


### PR DESCRIPTION
- Use phantom wallet from the browser / mobile to connect the user without having to go through the google login flow . 
- It allows the user to sign and get an organizaition / wallet they can use with local keypair generated on the device. 

This would allow any phantom user to connect using their phantom wallet and no need to go through onboarding, just signing a couple of messages