### PR TITLE
fix: release commit mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           version: yarn changeset version
           publish: yarn release
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN_PHANTOM_SECURITY_BOT }}


### PR DESCRIPTION
Set commit mode to github api to avoid commit signing manually