### PR TITLE
chore: mark @phantom/wallet-sdk as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ All packages with links to documentation:
 - **[@phantom/client](./packages/client/README.md)** - HTTP client library
 - **[@phantom/api-key-stamper](./packages/api-key-stamper/README.md)** - API authentication
 - **[@phantom/browser-injected-sdk](./packages/browser-injected-sdk/README.md)** - Browser extension integration
-- **@phantom/wallet-sdk (DEPRECATED)** - Legacy embedded wallet SDK
-- **@phantom/browser-embedded-sdk (DEPRECATED)** - Legacy browser embedded SDK
+
+### ⚠️ Deprecated Packages
+- **[@phantom/wallet-sdk](./packages/browser-embedded-sdk/README.md)** - ⚠️ **DEPRECATED** - Use [@phantom/browser-sdk](./packages/browser-sdk/README.md) or [@phantom/react-sdk](./packages/react-sdk/README.md) instead ([NPM](https://www.npmjs.com/package/@phantom/wallet-sdk))
 
 ## SDK Overview
 

--- a/packages/browser-embedded-sdk/README.md
+++ b/packages/browser-embedded-sdk/README.md
@@ -1,5 +1,14 @@
 # @phantom/wallet-sdk
 
+> **⚠️ DEPRECATED** 
+> 
+> This package (`@phantom/wallet-sdk`) is deprecated and will no longer receive updates. Please migrate to the new Phantom SDK packages:
+> 
+> - **[@phantom/react-sdk](../react-sdk/README.md)** - For React applications
+> - **[@phantom/browser-sdk](../browser-sdk/README.md)** - For vanilla JavaScript/TypeScript applications  
+> - **[@phantom/server-sdk](../server-sdk/README.md)** - For server-side applications
+>
+
 The Phantom Embedded Wallet SDK allows you to integrate Phantom's wallet functionality directly into your web application. It provides a simple interface for interacting with the wallet, including showing/hiding the wallet UI, performing swaps and purchases, and accessing chain-specific RPC interfaces for Solana, Ethereum, Sui, and Bitcoin.
 
 ## Installation


### PR DESCRIPTION
## Summary & Motivation

Adding clearer messages in READMEs that @phantom/wallet-sdk it is deprecated

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run `yarn changeset`. This will generate a file where you should write a human friendly summary about the changes. Please respect the versioning system - if any interface has been broken, we need to increase the major version.

## Did you update the README files?

If the interfaces of affected packages have changed, please ensure their README files are updated to reflect the new APIs and usage patterns.