### PR TITLE
fix: export type declaration chains

### DIFF
--- a/.changeset/fancy-lands-spend.md
+++ b/.changeset/fancy-lands-spend.md
@@ -1,0 +1,9 @@
+---
+"@phantom/chains": patch
+"@phantom/browser-sdk": patch
+"@phantom/react-native-sdk": patch
+"@phantom/react-sdk": patch
+"@phantom/react-ui": patch
+---
+
+Fixed exported types

--- a/packages/chains/package.json
+++ b/packages/chains/package.json
@@ -2,13 +2,9 @@
   "name": "@phantom/chains",
   "version": "1.0.0-beta.3",
   "description": "Shared chain interfaces for Phantom SDK",
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },
@@ -18,7 +14,7 @@
   "scripts": {
     "?pack-release": "When https://github.com/changesets/changesets/issues/432 has a solution we can remove this trick",
     "pack-release": "rimraf ./_release && yarn pack && mkdir ./_release && tar zxvf ./package.tgz --directory ./_release && rm ./package.tgz",
-    "build": "rimraf ./dist && tsup src/index.ts --format cjs,esm --dts --external @phantom/constants --external @phantom/parsers",
+    "build": "rimraf ./dist && tsc --project . --outDir dist --declaration --emitDeclarationOnly",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "test": "jest",


### PR DESCRIPTION
Chain types are not correctly picked in the built packages