### PR TITLE
fix: improve `BrowserSDKConfig` provider specific typing

### DIFF
--- a/examples/react-sdk-demo-app/src/App.tsx
+++ b/examples/react-sdk-demo-app/src/App.tsx
@@ -41,15 +41,13 @@ function App() {
   }, []);
 
   // SDK configuration - now dynamic based on provider type selection
-  const config: PhantomSDKConfig = useMemo(
-    () => ({
-      providerType: providerType, // Dynamic provider type
-      addressTypes: [AddressType.solana, AddressType.ethereum, AddressType.bitcoinSegwit, AddressType.sui],
+  const config: PhantomSDKConfig = useMemo(() => {
+    const addressTypes = [AddressType.solana, AddressType.ethereum, AddressType.bitcoinSegwit, AddressType.sui];
 
-
-      // Embedded wallet configuration (only used when providerType is "embedded")
-      ...(providerType === "embedded" && {
-        
+    if (providerType === "embedded") {
+      return {
+        providerType,
+        addressTypes,
         appId: import.meta.env.VITE_APP_ID || "your-app-id",
         apiBaseUrl: import.meta.env.VITE_API_BASE_URL || "https://api.phantom.app/v1/wallets",
         embeddedWalletType: embeddedWalletType,
@@ -57,11 +55,15 @@ function App() {
           authUrl: import.meta.env.VITE_AUTH_URL || "https://connect.phantom.app/login",
           redirectUrl: import.meta.env.VITE_REDIRECT_URL,
         },
-        autoConnect: true, // Automatically connect to existing session
-      }),
-    }),
-    [providerType, embeddedWalletType],
-  ); // Dependencies - will cause SDK reinstantiation when changed
+        autoConnect: true,
+      };
+    } else {
+      return {
+        providerType,
+        addressTypes,
+      };
+    }
+  }, [providerType, embeddedWalletType]); // Dependencies - will cause SDK reinstantiation when changed
 
   // Debug configuration - separate to avoid SDK reinstantiation
   const debugConfig: PhantomDebugConfig = useMemo(
@@ -86,18 +88,21 @@ function App() {
   );
 
   // Auth callback always needs embedded config
-  const authConfig: PhantomSDKConfig = useMemo(() => ({
-    providerType: "embedded",
-    addressTypes: [AddressType.solana, AddressType.ethereum, AddressType.bitcoinSegwit, AddressType.sui],
-    appId: import.meta.env.VITE_APP_ID || "your-app-id",
-    apiBaseUrl: import.meta.env.VITE_API_BASE_URL || "https://api.phantom.app/v1/wallets",
-    embeddedWalletType: "user-wallet", // Auth callback is always for user wallet
-    authOptions: {
-      authUrl: import.meta.env.VITE_AUTH_URL || "https://connect.phantom.app",
-      redirectUrl: import.meta.env.VITE_REDIRECT_URL,
-    },
-    autoConnect: true,
-  }), []);
+  const authConfig: PhantomSDKConfig = useMemo(
+    () => ({
+      providerType: "embedded",
+      addressTypes: [AddressType.solana, AddressType.ethereum, AddressType.bitcoinSegwit, AddressType.sui],
+      appId: import.meta.env.VITE_APP_ID || "your-app-id",
+      apiBaseUrl: import.meta.env.VITE_API_BASE_URL || "https://api.phantom.app/v1/wallets",
+      embeddedWalletType: "user-wallet", // Auth callback is always for user wallet
+      authOptions: {
+        authUrl: import.meta.env.VITE_AUTH_URL || "https://connect.phantom.app",
+        redirectUrl: import.meta.env.VITE_REDIRECT_URL,
+      },
+      autoConnect: true,
+    }),
+    [],
+  );
 
   return (
     <DebugContext.Provider value={debugContextValue}>

--- a/packages/browser-sdk/src/providers/injected/index.ts
+++ b/packages/browser-sdk/src/providers/injected/index.ts
@@ -32,7 +32,7 @@ declare global {
   }
 }
 
-interface InjectedProviderConfig {
+export interface InjectedProviderConfig {
   addressTypes: AddressType[];
 }
 
@@ -414,10 +414,7 @@ export class InjectedProvider implements Provider {
     // Add event listeners using browser-injected-sdk
     const cleanupConnect = this.phantom.solana.addEventListener("connect", handleSolanaConnect);
     const cleanupDisconnect = this.phantom.solana.addEventListener("disconnect", handleSolanaDisconnect);
-    const cleanupAccountChanged = this.phantom.solana.addEventListener(
-      "accountChanged",
-      handleSolanaAccountChanged,
-    );
+    const cleanupAccountChanged = this.phantom.solana.addEventListener("accountChanged", handleSolanaAccountChanged);
 
     // Store cleanup functions
     this.browserInjectedCleanupFunctions.push(cleanupConnect, cleanupDisconnect, cleanupAccountChanged);

--- a/packages/browser-sdk/src/types.ts
+++ b/packages/browser-sdk/src/types.ts
@@ -12,6 +12,7 @@ import type { ISolanaChain, IEthereumChain } from "@phantom/chain-interfaces";
 import { AddressType } from "@phantom/client";
 
 import type { DebugCallback, DebugLevel } from "./debug";
+import type { InjectedProviderConfig } from "./providers/injected";
 
 // Debug configuration - separate from SDK config to avoid unnecessary reinstantiation
 export interface DebugConfig {
@@ -20,20 +21,36 @@ export interface DebugConfig {
   callback?: DebugCallback;
 }
 
-export interface BrowserSDKConfig extends Partial<Omit<EmbeddedProviderConfig, "authOptions">> {
-  providerType: "injected" | "embedded" | (string & Record<never, never>);
-  addressTypes: [AddressType, ...AddressType[]];
-  // Required for embedded provider, optional for injected
+export type BrowserSDKConfig = Prettify<
+  (ExtendedEmbeddedProviderConfig | ExtendedInjectedProviderConfig) & {
+    autoConnect?: boolean;
+  }
+>;
+
+// Improves display of a merged type on hover
+type Prettify<T> = {
+  [K in keyof T]: T[K];
+  // eslint-disable-next-line @typescript-eslint/ban-types
+} & {};
+
+interface ExtendedEmbeddedProviderConfig
+  extends Omit<EmbeddedProviderConfig, "authOptions" | "apiBaseUrl" | "embeddedWalletType"> {
+  providerType: "embedded";
+  // Optional in the SDK
   apiBaseUrl?: string;
-  appId?: string; // the app id retrieved from phantom.com/portal (required for embedded provider)
-  embeddedWalletType?: "app-wallet" | "user-wallet" | (string & Record<never, never>);
-  // Auto-connect to existing sessions (default: true)
-  autoConnect?: boolean;
+  embeddedWalletType?: "app-wallet" | "user-wallet";
   authOptions?: {
     authUrl?: string;
     redirectUrl?: string;
   };
-  
+}
+
+interface ExtendedInjectedProviderConfig extends InjectedProviderConfig {
+  providerType: "injected";
+  // Omitted EmbeddedProviderConfig properties
+  appId?: never;
+  authOptions?: never;
+  embeddedWalletType?: never;
 }
 
 // Re-export types from core for convenience

--- a/packages/react-sdk/src/PhantomProvider.tsx
+++ b/packages/react-sdk/src/PhantomProvider.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext, useState, useEffect, useMemo } from "react";
 import { BrowserSDK } from "@phantom/browser-sdk";
 import type { BrowserSDKConfig, WalletAddress, AuthOptions, DebugConfig } from "@phantom/browser-sdk";
 
-export interface PhantomSDKConfig extends BrowserSDKConfig {}
+export type PhantomSDKConfig = BrowserSDKConfig;
 
 export interface PhantomDebugConfig extends DebugConfig {}
 
@@ -34,14 +34,8 @@ export interface PhantomProviderProps {
 
 export function PhantomProvider({ children, config, debugConfig }: PhantomProviderProps) {
   // Memoized config to avoid unnecessary SDK recreation
-  const memoizedConfig: BrowserSDKConfig = useMemo(() => {
-    return {
-      ...config,
-      // Use providerType if provided, default to embedded
-      providerType: config.providerType || "embedded",
-    };
-  }, [config]);
-  
+  const memoizedConfig: BrowserSDKConfig = useMemo(() => config, [config]);
+
   const [isConnected, setIsConnected] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
   const [connectError, setConnectError] = useState<Error | null>(null);
@@ -54,8 +48,6 @@ export function PhantomProvider({ children, config, debugConfig }: PhantomProvid
 
   // Eager initialization - SDK created immediately and never null
   const sdk = useMemo(() => new BrowserSDK(memoizedConfig), [memoizedConfig]);
-
-  
 
   // Event listener management - SDK already exists
   useEffect(() => {


### PR DESCRIPTION
## Summary & Motivation

The `BrowserSDKConfig` has varying configuration based on the provider type; injected or embedded. This improved the configuration, determining the required types by the `providerType`.

All associated type change requirements are adjusted appropriately.

## How I Tested These Changes

The project builds.

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run `yarn changeset`. This will generate a file where you should write a human friendly summary about the changes. Please respect the versioning system - if any interface has been broken, we need to increase the major version.

## Did you update the README files?

If the interfaces of affected packages have changed, please ensure their README files are updated to reflect the new APIs and usage patterns.