### PR TITLE
docs: fix broken link

### DIFF
--- a/packages/react-native-sdk/README.md
+++ b/packages/react-native-sdk/README.md
@@ -475,7 +475,7 @@ interface PhantomDebugConfig {
 
 ## Support
 
-- **Documentation**: [phantom.app/docs](https://phantom.app/docs)
+- **Documentation**: [phantom.app/docs](https://docs.phantom.com/introduction)
 - **GitHub Issues**: [github.com/phantom/wallet-sdk/issues](https://github.com/phantom/wallet-sdk/issues)
 
 ## License


### PR DESCRIPTION
https://phantom.app/docs - old
https://docs.phantom.com/introduction - new