### PR TITLE
Chore/remove unused is available rn adapters

### DIFF
--- a/packages/react-native-sdk/src/providers/embedded/auth.ts
+++ b/packages/react-native-sdk/src/providers/embedded/auth.ts
@@ -125,9 +125,4 @@ export class ExpoAuthProvider implements AuthProvider {
       await WebBrowser.coolDownAsync();
     }
   }
-
-  isAvailable(): Promise<boolean> {
-    // WebBrowser is always available in Expo
-    return Promise.resolve(true);
-  }
 }

--- a/packages/react-native-sdk/src/providers/embedded/storage.ts
+++ b/packages/react-native-sdk/src/providers/embedded/storage.ts
@@ -47,10 +47,6 @@ export class ExpoSecureStorage implements EmbeddedStorage {
     }
   }
 
-  async isAvailable(): Promise<boolean> {
-    return await SecureStore.isAvailableAsync();
-  }
-
   // Method to update authentication requirement
   setRequireAuth(_requireAuth: boolean): void {
     // Note: this.requireAuth is readonly, so we can't actually change it


### PR DESCRIPTION
- Delete non-interface and unused isAvailable() from ExpoSecureStorage and ExpoAuthProvider.
- Keeps API surface aligned with core interfaces (EmbeddedStorage, AuthProvider) and avoids confusion.
- No runtime behavior change; these methods were never referenced.