### PR TITLE
chore: add postinstall hook to build packages automatically

### DIFF
--- a/examples/browser-sdk-demo-app/package.json
+++ b/examples/browser-sdk-demo-app/package.json
@@ -4,9 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "predev": "yarn workspace @phantom/browser-sdk build:watch",
-    "dev": "concurrently \"yarn predev\" \"vite --port 5175\"",
-    "prebuild": "yarn workspace @phantom/browser-sdk build",
+    "dev": "concurrently \"yarn workspace @phantom/browser-sdk dev\" \"vite --port 5175\"",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "check-types": "tsc --noEmit"

--- a/examples/react-sdk-demo-app/package.json
+++ b/examples/react-sdk-demo-app/package.json
@@ -4,9 +4,7 @@
   "version": "0.0.2",
   "type": "module",
   "scripts": {
-    "predev": "yarn workspace @phantom/react-sdk build",
     "dev": "vite --port 5174",
-    "prebuild": "yarn workspace @phantom/react-sdk build",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "check-types": "tsc --noEmit",

--- a/examples/with-react-ui/package.json
+++ b/examples/with-react-ui/package.json
@@ -4,9 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "scripts": {
-    "predev": "yarn workspace @phantom/react-ui build && yarn workspace @phantom/react-sdk build && yarn workspace @phantom/browser-sdk build",
     "dev": "vite --port 5178",
-    "prebuild": "yarn workspace @phantom/react-ui build && yarn workspace @phantom/react-sdk build && yarn workspace @phantom/browser-sdk build",
     "build": "tsc -b && vite build",
     "check-types": "tsc --noEmit",
     "preview": "vite preview"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "check-types": "yarn workspaces foreach -Avpi run check-types",
     "release": "yarn build && yarn pack-release && yarn changeset publish",
     "test": "jest",
-    "watch": "node scripts/develop.mjs"
+    "watch": "node scripts/develop.mjs",
+    "postinstall": "yarn build"
   },
   "workspaces": [
     "packages/*",


### PR DESCRIPTION
## Summary & Motivation

On a fresh clone, developers had to manually run `yarn build` after `yarn install` because internal workspace dependencies failed to resolve. This happened because TypeScript packages build to `dist/` folders which don't exist until built, but these folders are referenced by workspace dependencies.

This PR adds a `postinstall` hook to the root `package.json` that automatically builds all packages in topological order after `yarn install`. This ensures that:
1. All `dist/` folders exist before development begins
2. Workspace dependencies resolve correctly immediately after install
3. Developers have a smooth experience: clone → install → develop

Also cleaned up manual `predev`/`prebuild` workarounds in example apps that are no longer necessary.

## How I Tested These Changes

Changes can be tested by:
1. Cloning the repo fresh
2. Running `yarn install` 
3. Verifying all packages build successfully
4. Running any example app's dev script immediately without additional build steps

## Did you add a changeset?

No changeset needed. This is an internal development workflow improvement that doesn't affect any published package APIs or behavior.

## Did you update the README files?

No README updates needed. This doesn't change any package interfaces or usage patterns.