### PR TITLE
wip: Have SDK query for user policies

### DIFF
--- a/packages/client/src/PhantomClient.ts
+++ b/packages/client/src/PhantomClient.ts
@@ -241,21 +241,13 @@ export class PhantomClient {
       };
 
       // POC: Pre-fetch organization data so we can inspect policies in the network tab
-      // This call is signed by the user's keypair via the axios stamper interceptor
+      // Use the existing public getOrganization method which handles auth properly
       try {
-        const orgRequest: any = {
-          method: "getOrganization",
-          params: {
-            organizationId: this.config.organizationId,
-          },
-          timestampMs: await getSecureTimestamp(),
-        };
-        // Fire and await to ensure it shows before signing
-        const orgResponse = await this.kmsApi.postKmsRpc(orgRequest);
-        console.log("Organization data (check for policies):", orgResponse.data);
+        const orgData = await this.getOrganization(this.config.organizationId);
+        console.log("Organization data (check for policies):", orgData);
       } catch (e: any) {
         // Do not block signing on org fetch errors in this POC
-        console.warn("getOrganization failed", e?.response?.data || e?.message || e);
+        console.warn("getOrganization failed", e?.message || e);
       }
 
       // Sign transaction request - include configs if available


### PR DESCRIPTION
## Summary & Motivation

With this change, the SDK can learn what the users policies are - specifically what the user's set spending limit is, so we can parse/pass the spending limit onto the wallet service.

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run `yarn changeset`. This will generate a file where you should write a human friendly summary about the changes. Please respect the versioning system - if any interface has been broken, we need to increase the major version.

## Did you update the README files?

If the interfaces of affected packages have changed, please ensure their README files are updated to reflect the new APIs and usage patterns.