### PR TITLE
chore: add Linear issue and PR title checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Linear Issue Check
         uses: phantom/linear-pr-check@f2a85fcbc7af8c2909f1869ccad4f8d66a5c98fa # 1.0.6 # 1.0.6
         with:
-          prefixes: "BEPLAT,CASH,CHAINS,DATA,DES,DEVRE,FEPLAT,IM,INF,LEG,ON,PD,PHA,QA,SEC,SOC,TRADE,TRA,WEB,DX,WP,COR,TPLAT,ADV,PERP,SDLC,AID,GROW"
+          prefixes: "BEPLAT,CASH,CHAINS,DATA,DES,DEVRE,FEPLAT,IDPLAT,IM,INF,LEG,ON,PD,PHA,QA,SEC,SOC,TRADE,TRA,WEB,DX,WP,COR,TPLAT,ADV,PERP,SDLC,AID,GROW"
           exceptionTitlePrefixes: "chore,docs,style"
 
   title-check:


### PR DESCRIPTION
Resolves WP-7589

## Summary & Motivation

This adds CI checks to ensure a Linear issue exists for the change being made, as well as a conventional title check.

## How I Tested These Changes

Observe the CI passing on this PR.

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run `yarn changeset`. This will generate a file where you should write a human friendly summary about the changes. Please respect the versioning system - if any interface has been broken, we need to increase the major version.

## Did you update the README files?

If the interfaces of affected packages have changed, please ensure their README files are updated to reflect the new APIs and usage patterns.