### PR TITLE
refactor: migrate from `signRawPayload` to `signUtf8Message`

### DIFF
--- a/packages/client/src/PhantomClient.ts
+++ b/packages/client/src/PhantomClient.ts
@@ -8,8 +8,8 @@ import {
   GetAccountsMethodEnum,
   GrantOrganizationAccessMethodEnum,
   KMSRPCApi,
-  SignRawPayloadMethodEnum,
   SignTransactionMethodEnum,
+  SignUTF8MessageMethodEnum,
   type UserPolicy,
   UserPolicyOneOfTypeEnum,
   type DerivationInfoAddressFormatEnum as AddressType,
@@ -33,10 +33,10 @@ import {
   type PartialKmsUser,
   type SignatureWithPublicKey,
   type SignedTransactionWithPublicKey,
-  type SignRawPayload,
-  type SignRawPayloadRequest,
   type SignTransaction,
   type SignTransactionRequest,
+  type SignUTF8Message,
+  type SignUtf8MessageRequest,
 } from "@phantom/openapi-wallet-service";
 import axios, { type AxiosInstance } from "axios";
 import { Buffer } from "buffer";
@@ -404,9 +404,9 @@ export class PhantomClient {
   }
 
   /**
-   * Sign a raw payload for now used for Solana Sign Message
+   * Sign a UTF-8 message for Solana
    */
-  async signRawPayload(params: SignMessageParams): Promise<string> {
+  async signUtf8Message(params: SignMessageParams): Promise<string> {
     const walletId = params.walletId;
     const messageParam = params.message;
     const networkIdParam = params.networkId;
@@ -429,22 +429,19 @@ export class PhantomClient {
         addressFormat: networkConfig.addressFormat,
       };
 
-      // Message is already base64url encoded
-      const base64StringMessage = messageParam;
-
-      const signRequest: SignRawPayloadRequest = {
+      const signRequest: SignUtf8MessageRequest = {
         organizationId: this.config.organizationId,
         walletId: walletId,
-        payload: base64StringMessage as any,
+        message: messageParam,
         algorithm: networkConfig.algorithm,
         derivationInfo: derivationInfo,
       };
 
-      const request: SignRawPayload = {
-        method: SignRawPayloadMethodEnum.signRawPayload,
+      const request: SignUTF8Message & { timestampMs: number } = {
+        method: SignUTF8MessageMethodEnum.signUtf8Message,
         params: signRequest,
         timestampMs: await getSecureTimestamp(),
-      } as any;
+      };
 
       const response = await this.kmsApi.postKmsRpc(request);
       const result = (response.data as any).result as SignatureWithPublicKey;

--- a/packages/embedded-provider-core/src/auth-flow.test.ts
+++ b/packages/embedded-provider-core/src/auth-flow.test.ts
@@ -176,7 +176,7 @@ describe("EmbeddedProvider Auth Flows", () => {
       createWallet: jest.fn(),
       getWalletAddresses: jest.fn(),
       ethereumSignMessage: jest.fn(),
-      signRawPayload: jest.fn(),
+      signUtf8Message: jest.fn(),
       signAndSendTransaction: jest.fn(),
     } as any;
     mockedPhantomClient.mockImplementation(() => mockClient);
@@ -1093,14 +1093,14 @@ describe("EmbeddedProvider Auth Flows", () => {
     });
 
     it("should sign messages when connected", async () => {
-      mockClient.signRawPayload.mockResolvedValue("signed-message-signature");
+      mockClient.signUtf8Message.mockResolvedValue("signed-message-signature");
 
       const result = await provider.signMessage({
         message: "test message",
         networkId: NetworkId.SOLANA_MAINNET,
       });
 
-      expect(mockClient.signRawPayload).toHaveBeenCalledWith({
+      expect(mockClient.signUtf8Message).toHaveBeenCalledWith({
         walletId: "wallet-123",
         message: expect.any(String),
         networkId: NetworkId.SOLANA_MAINNET,

--- a/packages/embedded-provider-core/src/embedded-provider.test.ts
+++ b/packages/embedded-provider-core/src/embedded-provider.test.ts
@@ -251,7 +251,7 @@ describe("EmbeddedProvider Core", () => {
 
       provider["client"] = {
         ethereumSignMessage: jest.fn().mockResolvedValue("signed-message"),
-        signRawPayload: jest.fn().mockResolvedValue("signed-message"),
+        signUtf8Message: jest.fn().mockResolvedValue("signed-message"),
       } as any;
       provider["walletId"] = "test-wallet-id";
 
@@ -262,8 +262,8 @@ describe("EmbeddedProvider Core", () => {
       });
 
       // The stamper won't be called directly for signMessage - the client handles it
-      // But we can verify the client's signRawPayload was called (for Solana)
-      expect(provider["client"].signRawPayload).toHaveBeenCalled();
+      // But we can verify the client's signUtf8Message was called (for Solana)
+      expect(provider["client"].signUtf8Message).toHaveBeenCalled();
     });
 
     it.skip("should call platform stamper getKeyInfo during client initialization", async () => {

--- a/packages/embedded-provider-core/src/embedded-provider.ts
+++ b/packages/embedded-provider-core/src/embedded-provider.ts
@@ -723,17 +723,14 @@ export class EmbeddedProvider {
       message: params.message,
     });
 
-    // Parse message to base64url format for client
-    const base64UrlMessage = stringToBase64url(params.message);
-
     // Get session to access derivation index
     const session = await this.storage.getSession();
     const derivationIndex = session?.accountDerivationIndex ?? 0;
 
     // Get raw response from client - use the appropriate method based on chain
-    const rawResponse = await this.client.signRawPayload({
+    const rawResponse = await this.client.signUtf8Message({
       walletId: this.walletId,
-      message: base64UrlMessage,
+      message: params.message,
       networkId: params.networkId,
       derivationIndex: derivationIndex,
     });

--- a/packages/server-sdk/src/index.ts
+++ b/packages/server-sdk/src/index.ts
@@ -1,6 +1,5 @@
 import {
   PhantomClient,
-  type SignMessageParams,
   type NetworkId,
   type CreateWalletResult,
   type GetWalletsResult,
@@ -113,20 +112,13 @@ export class ServerSDK {
    * @returns Promise<ParsedSignatureResult> - Parsed signature with explorer URL
    */
   async signMessage(params: ServerSignMessageParams): Promise<ParsedSignatureResult> {
-    // Parse the message to base64url format
-    const base64UrlMessage = stringToBase64url(params.message);
-
-    const signMessageParams: SignMessageParams = {
-      walletId: params.walletId,
-      message: base64UrlMessage,
-      networkId: params.networkId,
-      derivationIndex: params.derivationIndex,
-    };
-
     // Get raw response from client - use the appropriate method based on chain
     const rawResponse = isEthereumChain(params.networkId)
-      ? await this.client.ethereumSignMessage(signMessageParams)
-      : await this.client.signRawPayload(signMessageParams);
+      ? await this.client.ethereumSignMessage({
+          ...params,
+          message: stringToBase64url(params.message),
+        })
+      : await this.client.signUtf8Message(params);
 
     // Parse the response to get human-readable signature and explorer URL
     return parseSignMessageResponse(rawResponse, params.networkId);


### PR DESCRIPTION
## Summary & Motivation

We do not need to sign a raw payload when signing a message. As such, this migrates Solana message signing from `signRawPayload` to `signUtf8Message`.

## How I Tested These Changes

Running the example before and after the changes resulted in the same signature.