### PR TITLE
fix: install newer npm for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
           cache: "yarn"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Ensure npm 11.5.1+ for trusted publishing
+        run: npm install -g npm@^11.5.1
+
       - name: Install Dependencies
         run: yarn install --immutable
 


### PR DESCRIPTION
## Summary & Motivation
Trusted publishing requires NPM 11.5.1 at least but setup node step installed 10.x

SEC-3633

## How I Tested These Changes

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run `yarn changeset`. This will generate a file where you should write a human friendly summary about the changes. Please respect the versioning system - if any interface has been broken, we need to increase the major version.

## Did you update the README files?

If the interfaces of affected packages have changed, please ensure their README files are updated to reflect the new APIs and usage patterns.