### PR TITLE
fix: add repo provenance info

### DIFF
--- a/packages/api-key-stamper/package.json
+++ b/packages/api-key-stamper/package.json
@@ -2,6 +2,11 @@
   "name": "@phantom/api-key-stamper",
   "version": "1.0.0-beta.11",
   "description": "API key stamper for Phantom Wallet SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/api-key-stamper"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/base64url/package.json
+++ b/packages/base64url/package.json
@@ -2,6 +2,11 @@
   "name": "@phantom/base64url",
   "version": "1.0.0-beta.11",
   "description": "Isomorphic base64url encoding/decoding utilities",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/base64url"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/browser-embedded-sdk/package.json
+++ b/packages/browser-embedded-sdk/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@phantom/wallet-sdk",
   "version": "0.1.3-beta.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/browser-embedded-sdk"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/browser-injected-sdk/package.json
+++ b/packages/browser-injected-sdk/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@phantom/browser-injected-sdk",
   "version": "1.0.0-beta.8",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/browser-injected-sdk"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/browser-sdk/package.json
+++ b/packages/browser-sdk/package.json
@@ -2,6 +2,11 @@
   "name": "@phantom/browser-sdk",
   "version": "1.0.0-beta.23",
   "description": "Browser SDK for Phantom Wallet",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/browser-sdk"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/chain-interfaces/package.json
+++ b/packages/chain-interfaces/package.json
@@ -35,8 +35,8 @@
   "author": "Phantom",
   "repository": {
     "type": "git",
-    "url": "https://github.com/phantom/wallet-sdk.git",
-    "directory": "packages/chains"
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/chain-interfaces"
   },
   "dependencies": {
     "@phantom/constants": "workspace:^",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -2,6 +2,11 @@
   "name": "@phantom/client",
   "version": "1.0.0-beta.23",
   "description": "HTTP client for Phantom Wallet API",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/client"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -2,6 +2,11 @@
   "name": "@phantom/constants",
   "version": "1.0.0-beta.11",
   "description": "Shared constants for Phantom Wallet SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/constants"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -2,6 +2,11 @@
   "name": "@phantom/crypto",
   "version": "1.0.0-beta.11",
   "description": "Cryptographic utilities for Phantom SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/crypto"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/embedded-provider-core/package.json
+++ b/packages/embedded-provider-core/package.json
@@ -2,6 +2,11 @@
   "name": "@phantom/embedded-provider-core",
   "version": "1.0.0-beta.23",
   "description": "Platform-agnostic embedded provider core logic for Phantom Wallet SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/embedded-provider-core"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",

--- a/packages/indexed-db-stamper/package.json
+++ b/packages/indexed-db-stamper/package.json
@@ -2,6 +2,11 @@
   "name": "@phantom/indexed-db-stamper",
   "version": "1.0.0-beta.4",
   "description": "IndexedDB stamper for Phantom Wallet SDK with non-extractable key storage",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/indexed-db-stamper"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/parsers/package.json
+++ b/packages/parsers/package.json
@@ -2,6 +2,11 @@
   "name": "@phantom/parsers",
   "version": "1.0.0-beta.11",
   "description": "Transaction and message parsers for Phantom Wallet SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/parsers"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/react-native-sdk/package.json
+++ b/packages/react-native-sdk/package.json
@@ -41,7 +41,7 @@
   "author": "Phantom",
   "repository": {
     "type": "git",
-    "url": "https://github.com/phantom/wallet-sdk.git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
     "directory": "packages/react-native-sdk"
   },
   "dependencies": {

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@phantom/react-sdk",
   "version": "1.0.0-beta.23",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/react-sdk"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/sdk-types/package.json
+++ b/packages/sdk-types/package.json
@@ -2,6 +2,11 @@
   "name": "@phantom/sdk-types",
   "version": "1.0.0-beta.11",
   "description": "Common types for Phantom SDK packages",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/sdk-types"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/server-sdk/package.json
+++ b/packages/server-sdk/package.json
@@ -2,6 +2,11 @@
   "name": "@phantom/server-sdk",
   "version": "1.0.0-beta.23",
   "description": "Server SDK for Phantom Wallet",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/server-sdk"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@phantom/wallet-sdk-ui",
   "version": "1.0.0-beta.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/ui"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,6 +2,11 @@
   "name": "@phantom/utils",
   "version": "1.0.0-beta.23",
   "description": "Utility functions for Phantom Wallet SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/phantom/phantom-connect-sdk",
+    "directory": "packages/utils"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary & Motivation
This adds the provenance info needed for sigstore

SEC-3633

## How I Tested These Changes
Read the docs and added the missing info

## Did you add a changeset?

If updating one of our packages, you'll likely need to add a changeset to your PR. To do so, run `yarn changeset`. This will generate a file where you should write a human friendly summary about the changes. Please respect the versioning system - if any interface has been broken, we need to increase the major version.

## Did you update the README files?

If the interfaces of affected packages have changed, please ensure their README files are updated to reflect the new APIs and usage patterns.