### PR TITLE
chore: handle backend messages

### DIFF
--- a/.changeset/sunny-planes-fix.md
+++ b/.changeset/sunny-planes-fix.md
@@ -1,0 +1,21 @@
+---
+"@phantom/api-key-stamper": patch
+"@phantom/base64url": patch
+"@phantom/browser-injected-sdk": patch
+"@phantom/browser-sdk": patch
+"@phantom/chain-interfaces": patch
+"@phantom/client": patch
+"@phantom/constants": patch
+"@phantom/crypto": patch
+"@phantom/embedded-provider-core": patch
+"@phantom/indexed-db-stamper": patch
+"@phantom/parsers": patch
+"@phantom/react-native-sdk": patch
+"@phantom/react-sdk": patch
+"@phantom/sdk-types": patch
+"@phantom/server-sdk": patch
+"@phantom/wallet-sdk-ui": patch
+"@phantom/utils": patch
+---
+
+Fix prepare error response parsing

--- a/packages/client/src/PhantomClient.test.ts
+++ b/packages/client/src/PhantomClient.test.ts
@@ -513,7 +513,33 @@ describe("PhantomClient Spending Limits Integration", () => {
           },
           true,
         ),
-      ).rejects.toThrow("Failed to apply spending limits for this transaction");
+      ).rejects.toThrow("Failed to submit transaction");
+    });
+
+    it("should throw detail message when prepare endpoint returns transaction-blocked error", async () => {
+      mockAxiosPost.mockRejectedValueOnce({
+        response: {
+          data: {
+            type: "transaction-blocked",
+            title: "This transaction has been blocked",
+            detail: "account does not have enough SOL to perform the operation",
+          },
+        },
+      });
+
+      const performSigning = client["performTransactionSigning"].bind(client);
+
+      await expect(
+        performSigning(
+          {
+            walletId: "wallet-123",
+            transaction: "tx",
+            networkId: NetworkId.SOLANA_MAINNET,
+            account: "UserAccount123",
+          },
+          true,
+        ),
+      ).rejects.toThrow("account does not have enough SOL to perform the operation");
     });
 
     it("should continue signing when prepare endpoint returns pass-through with no limits", async () => {

--- a/packages/client/src/PhantomClient.ts
+++ b/packages/client/src/PhantomClient.ts
@@ -221,7 +221,12 @@ export class PhantomClient {
       });
       return response.data;
     } catch (error: any) {
-      throw new Error(`Failed to prepare transaction: ${error.response?.data?.message || error.message}`);
+      // If it's a transaction-blocked error, throw just the detail message
+      const errorData = error.response?.data;
+      if (errorData?.type === "transaction-blocked" && errorData?.detail) {
+        throw new Error(errorData.detail);
+      }
+      throw new Error(`Failed to prepare transaction: ${errorData?.message || error.message}`);
     }
   }
 
@@ -258,10 +263,7 @@ export class PhantomClient {
         return prepareResponse.transaction;
       } catch (e: unknown) {
         const errorMessage = e instanceof Error ? e.message : String(e);
-        throw new Error(
-          `Failed to apply spending limits for this transaction: ${errorMessage}. ` +
-            `Transaction cannot proceed without spending limit enforcement.`,
-        );
+        throw new Error(`Failed to submit transaction: ${errorMessage}`);
       }
     }
 


### PR DESCRIPTION
Handles the message of the backend instead of talking about spending limits

https://linear.app/phantom-labs/issue/WP-7874/message-for-prepare-error-is-not-clear